### PR TITLE
Fix stratos job by creating scf-config-values.yaml for stratos

### DIFF
--- a/cap-ci/pipeline.template
+++ b/cap-ci/pipeline.template
@@ -128,8 +128,14 @@ resources:
 ` }}
 
 {{- $stratos := `
-            # deploy stratos console & metrics
+            # obtain scf-config-values.yaml for stratos
             export QUIET_OUTPUT=true
+            export SCF_TESTGROUP=true
+            export SCF_OPERATOR=true
+            export DOCKER_ORG=cap-staging
+            make scf-gen-config
+            # deploy stratos console & metrics
+            unset DOCKER_ORG
             make stratos metrics
 ` }}
 


### PR DESCRIPTION
This PR updates the stratos&metrics job to compute correctly an scf-config-values.yaml file for stratos installs to work.

Tested and working:
https://concourse.suse.dev/teams/main/pipelines/fix-scf-clean-cap-release/jobs/stratos-diego-caasp4-ha/builds/2