### PR TITLE
Extended pipeline creator and template with parametrization of brain tests.

### DIFF
--- a/cap-ci/create_cap-release_pipeline.sh
+++ b/cap-ci/create_cap-release_pipeline.sh
@@ -11,9 +11,18 @@ export BACKEND="${BACKEND:-backend: [ caasp4, aks, gke, eks ]}"
 export OPTIONS="${OPTIONS:-options: [ sa, ha, all ]}"
 export EIRINI="${EIRINI:-eirini: [ diego, eirini ]}"
 
+export BRAIN_VERBOSE="${BRAIN_VERBOSE:-false}"
+export BRAIN_INORDER="${BRAIN_INORDER:-false}"
+export BRAIN_INCLUDE="${BRAIN_INCLUDE:-}"
+export BRAIN_EXCLUDE="${BRAIN_EXCLUDE:-}"
+
 gomplate -d 'BACKEND=env:///BACKEND?type=application/yaml' \
          -d 'OPTIONS=env:///OPTIONS?type=application/yaml' \
          -d 'EIRINI=env:///EIRINI?type=application/yaml' \
+         -d 'BRAIN_VERBOSE=env:///BRAIN_VERBOSE' \
+         -d 'BRAIN_INORDER=env:///BRAIN_INORDER' \
+         -d 'BRAIN_INCLUDE=env:///BRAIN_INCLUDE' \
+         -d 'BRAIN_EXCLUDE=env:///BRAIN_EXCLUDE' \
          -f pipeline.template > "$PIPELINE".yaml
 
 fly -t concourse.suse.dev sp -c "$PIPELINE".yaml -p "$PIPELINE"

--- a/cap-ci/pipeline.template
+++ b/cap-ci/pipeline.template
@@ -190,6 +190,10 @@ jobs:
       - name: s3.kubecf-bundle
       - name: pool.kube-hosts
       params:
+        BRAIN_VERBOSE: {{(ds "BRAIN_VERBOSE")}}
+        BRAIN_INORDER: {{(ds "BRAIN_INORDER")}}
+        BRAIN_INCLUDE: "{{(ds "BRAIN_INCLUDE")}}"
+        BRAIN_EXCLUDE: "{{(ds "BRAIN_EXCLUDE")}}"
         QUIET_OUTPUT: true
         DEFAULT_STACK: cflinuxfs3
 {{- if eq $EiriniFlag "eirini" }}


### PR DESCRIPTION
Ref: https://jira.suse.com/browse/CAP-1353

See also https://github.com/SUSE/catapult/pull/160 and https://github.com/SUSE/brain-tests-release/pull/12

Testing: Created and then inspected a pipeline definition. Not uploaded to a concourse though. Requires the above-referenced catapult and brain-test-release work to be properly functional.

