### PR TITLE
 Consume deps inside of docker catapult CI image

### DIFF
--- a/cap-ci/pipeline.template
+++ b/cap-ci/pipeline.template
@@ -79,6 +79,7 @@ resources:
             # create builfolder prepared for gke
             export BACKEND=gke
             printf "%s" '((gke-key-json))' > $PWD/gke-key.json
+            # GKE var exported here tso hijacking doesn't contain them in env
             export GKE_CRED_JSON=$PWD/gke-key.json
             export KUBECFG=$PWD/kubeconfig_$CLUSTER_NAME
             make kubeconfig
@@ -87,6 +88,7 @@ resources:
 {{- $import_eks := `
             # create builfolder prepared for eks
             export BACKEND=eks
+            # AWS vars exported here so hijacking doesn't contain them in env
             export AWS_ACCESS_KEY_ID='((aws-ci-chuller-access-key-id))'
             export AWS_SECRET_ACCESS_KEY='((aws-ci-chuller-secret-access-key))'
             export KUBECFG=$PWD/kubeconfig_$CLUSTER_NAME
@@ -135,7 +137,7 @@ resources:
             export DOCKER_ORG=cap-staging
             make scf-gen-config
             # deploy stratos console & metrics
-            unset DOCKER_ORG
+            unset DOCKER_ORG # consume docker images from DOCKER_ORG=cap on stratos & metrics
             make stratos metrics
 ` }}
 

--- a/cap-ci/pipeline.template
+++ b/cap-ci/pipeline.template
@@ -191,6 +191,7 @@ jobs:
       - name: pool.kube-hosts
       params:
         QUIET_OUTPUT: true
+        DOWNLOAD_CATAPULT_DEPS: false
         DEFAULT_STACK: cflinuxfs3
 {{- if eq $EiriniFlag "eirini" }}
         ENABLE_EIRINI: true
@@ -248,6 +249,7 @@ jobs:
       - name: pool.kube-hosts
       params:
         QUIET_OUTPUT: true
+        DOWNLOAD_CATAPULT_DEPS: false
         DEFAULT_STACK: cflinuxfs3
 {{- if eq $EiriniFlag "eirini" }}
         ENABLE_EIRINI: true
@@ -306,6 +308,7 @@ jobs:
       - name: pool.kube-hosts
       params:
         QUIET_OUTPUT: true
+        DOWNLOAD_CATAPULT_DEPS: false
         DEFAULT_STACK: cflinuxfs3
 {{- if eq $EiriniFlag "eirini" }}
         ENABLE_EIRINI: true
@@ -364,6 +367,7 @@ jobs:
       - name: pool.kube-hosts
       params:
         QUIET_OUTPUT: true
+        DOWNLOAD_CATAPULT_DEPS: false
         DEFAULT_STACK: cflinuxfs3
 {{- if eq $EiriniFlag "eirini" }}
         ENABLE_EIRINI: true
@@ -422,6 +426,7 @@ jobs:
       - name: pool.kube-hosts
       params:
         QUIET_OUTPUT: true
+        DOWNLOAD_CATAPULT_DEPS: false
         DEFAULT_STACK: cflinuxfs3
 {{- if eq $EiriniFlag "eirini" }}
         ENABLE_EIRINI: true
@@ -483,6 +488,7 @@ jobs:
       - name: pool.kube-hosts
       params:
         QUIET_OUTPUT: true
+        DOWNLOAD_CATAPULT_DEPS: false
         DEFAULT_STACK: cflinuxfs3
 {{- if eq $EiriniFlag "eirini" }}
         ENABLE_EIRINI: true
@@ -543,6 +549,7 @@ jobs:
       - name: pool.kube-hosts
       params:
         QUIET_OUTPUT: true
+        DOWNLOAD_CATAPULT_DEPS: false
         DEFAULT_STACK: cflinuxfs3
 {{- if eq $EiriniFlag "eirini" }}
         ENABLE_EIRINI: true


### PR DESCRIPTION
This makes catapult consume yq, yaml-patch, bazel, aws, gcloud, az, terraform,
etc from the catapult CI image run by concourse.

See: SUSE/catapult#162

