### PR TITLE
Trigger pipeline for new stratos console and metrics charts

### DIFF
--- a/cap-ci/pipeline.template
+++ b/cap-ci/pipeline.template
@@ -130,6 +130,7 @@ resources:
 ` }}
 
 {{- $deploy := `
+            # Attention: PWD = ___/catapult here
             # deploy kubecf from chart
             export SCF_CHART="$(readlink -f ../s3.kubecf-bundle/*.tgz)"
             export SCF_TESTGROUP=true
@@ -140,6 +141,7 @@ resources:
 ` }}
 
 {{- $test := `
+            # Attention: PWD = ___/catapult here
             # run test suites on cluster
             # See: https://github.com/SUSE/catapult/wiki/Running-SCF-tests#kubecf
             export KUBECF_TEST_SUITE="${TEST_SUITE:-smokes}"
@@ -150,6 +152,7 @@ resources:
 ` }}
 
 {{- $stratos := `
+            # Attention: PWD = ____/catapult here
             # obtain scf-config-values.yaml for stratos
             export QUIET_OUTPUT=true
             export SCF_TESTGROUP=true
@@ -164,6 +167,7 @@ resources:
 ` }}
 
 {{- $upgrade := `
+            # Attention: PWD = ___/catapult here
             # upgrade kubecf
             export SCF_CHART="$(readlink -f ../s3.kubecf-bundle/*.tgz)"
             export SCF_OPERATOR=true

--- a/cap-ci/pipeline.template
+++ b/cap-ci/pipeline.template
@@ -137,6 +137,7 @@ resources:
             export SCF_OPERATOR=true
             export DOCKER_ORG=cap-staging
             export QUIET_OUTPUT=true
+            env | sort | sed -e 's|^|CONFIGURATION: |'
             make scf && make scf-login # ensure scf is there
 ` }}
 
@@ -148,6 +149,7 @@ resources:
             export KUBECF_NAMESPACE="scf"
             export SCF_TESTGROUP=true
             export QUIET_OUTPUT=true
+            env | sort | sed -e 's|^|CONFIGURATION: |'
             make tests-kubecf
 ` }}
 
@@ -163,6 +165,7 @@ resources:
             export STRATOS_CHART="$(readlink -f ../helm-chart.stratos-chart/*.tgz)"
             export METRICS_CHART="$(readlink -f ../helm-chart.stratos-metrics-chart/*.tgz)"
             unset DOCKER_ORG # consume docker images from DOCKER_ORG=cap on stratos & metrics
+            env | sort | sed -e 's|^|CONFIGURATION: |'
             make stratos metrics
 ` }}
 
@@ -173,6 +176,7 @@ resources:
             export SCF_OPERATOR=true
             export DOCKER_ORG=cap-staging
             export QUIET_OUTPUT=true
+            env | sort | sed -e 's|^|CONFIGURATION: |'
             make scf-chart # this takes the same chart as the deploy step for now
             make scf-gen-config
             make scf-upgrade

--- a/cap-ci/pipeline.template
+++ b/cap-ci/pipeline.template
@@ -37,6 +37,11 @@ resource_types:
     repository: resource/github-status
     tag: release
 
+- name: helm-chart
+  type: docker-image
+  source:
+    repository: linkyard/helm-chart-resource
+
 resources:
 - name: catapult
   type: git

--- a/cap-ci/pipeline.template
+++ b/cap-ci/pipeline.template
@@ -61,22 +61,18 @@ resources:
 - name: helm-chart.stratos-chart
   type: helm-chart
   source:
-    chart:
+    chart: stratos/console
     repos:
-    - name:
-      url:
-      username:
-      password:
+    - name: stratos
+      url: http://opensource.suse.com/stratos/
 
 - name: helm-chart.stratos-metrics-chart
   type: helm-chart
   source:
-    chart:
+    chart: stratos-metrics/metrics
     repos:
-    - name:
-      url:
-      username:
-      password:
+    - name: stratos-metrics
+      url: http://opensource.suse.com/stratos-metrics/
 
 # Pool resource with kube cluster information
 {{ range $_, $Backend := (ds "BACKEND").backend -}} # for all backends
@@ -161,6 +157,8 @@ resources:
             export DOCKER_ORG=cap-staging
             make scf-gen-config
             # deploy stratos console & metrics
+            export STRATOS_CHART="$(readlink -f ../helm-chart.stratos-chart/*.tgz)"
+            export METRICS_CHART="$(readlink -f ../helm-chart.stratos-metrics-chart/*.tgz)"
             unset DOCKER_ORG # consume docker images from DOCKER_ORG=cap on stratos & metrics
             make stratos metrics
 ` }}
@@ -195,6 +193,10 @@ jobs:
   public: false
   plan:
   - get: s3.kubecf-bundle
+    trigger: true
+  - get: helm-chart.stratos-chart
+    trigger: true
+  - get: helm-chart.stratos-metrics-chart
     trigger: true
   - get: catapult
   - put: {{$Backend}}-pool.kube-hosts
@@ -559,6 +561,8 @@ jobs:
   public: false
   plan:
   - get: catapult
+  - get: helm-chart.stratos-chart
+  - get: helm-chart.stratos-metrics-chart
   - get: {{$Backend}}-pool.kube-hosts
     passed:
     - upgrade-{{$EiriniFlag}}-{{$Backend}}-{{$OptionsFlag}}
@@ -576,6 +580,8 @@ jobs:
           repository: splatform/catapult
       inputs:
       - name: catapult
+      - name: helm-chart.stratos-chart
+      - name: helm-chart.stratos-metrics-chart
       - name: pool.kube-hosts
       params:
         QUIET_OUTPUT: true

--- a/cap-ci/pipeline.template
+++ b/cap-ci/pipeline.template
@@ -96,7 +96,7 @@ resources:
 ` }}
 
 {{- $import_gke := `
-            # create builfolder prepared for gke
+            # create buildfolder prepared for gke
             export BACKEND=gke
             printf "%s" '((gke-key-json))' > $PWD/gke-key.json
             # GKE var exported here tso hijacking doesn't contain them in env
@@ -106,7 +106,7 @@ resources:
 ` }}
 
 {{- $import_eks := `
-            # create builfolder prepared for eks
+            # create buildfolder prepared for eks
             export BACKEND=eks
             # AWS vars exported here so hijacking doesn't contain them in env
             export AWS_ACCESS_KEY_ID='((aws-ci-chuller-access-key-id))'
@@ -116,7 +116,7 @@ resources:
 ` }}
 
 {{- $import_aks := `
-            # create builfolder prepared for aks
+            # create buildfolder prepared for aks
             export BACKEND=aks
             export KUBECFG=$PWD/kubeconfig_$CLUSTER_NAME
             make kubeconfig

--- a/cap-ci/pipeline.template
+++ b/cap-ci/pipeline.template
@@ -58,6 +58,25 @@ resources:
     region_name: us-west-2
     regexp: kubecf-bundle-v(.*).tgz
 
+- name: helm-chart.stratos-chart
+  type: helm-chart
+  source:
+    chart:
+    repos:
+    - name:
+      url:
+      username:
+      password:
+
+- name: helm-chart.stratos-metrics-chart
+  type: helm-chart
+  source:
+    chart:
+    repos:
+    - name:
+      url:
+      username:
+      password:
 
 # Pool resource with kube cluster information
 {{ range $_, $Backend := (ds "BACKEND").backend -}} # for all backends


### PR DESCRIPTION
Ref https://jira.suse.com/browse/CAP-1352

- Pipeline extended to watch the official helm repositories for the stratos charts (console, metrics).
- New charts trigger the pipeline.
- Modified the stratos task to use the current charts from the repos.

Testing so far:
- Manual using a temp pipeline where the stratos task extensions were added to the deploy task
- Checked that the charts do trigger the pipeline
- Checked that the charts are in the input, and that the code accessing them returns the proper paths.

Issues with deploying to the test cluster outside of this pipeline (change) prevented full testing, especially that the catapult targets for stratos deploy pick up the charts from the resources/inputs.


