### PR TITLE
Draft work on dynamic cluster creation for AWS EKS

### DIFF
--- a/cap-ci/pipeline.template
+++ b/cap-ci/pipeline.template
@@ -24,7 +24,6 @@ groups:
 {{ end }} # end options
 {{ end }} # end backend
 
-
 resource_types:
 - name: pull-request
   type: docker-image
@@ -53,9 +52,9 @@ resources:
     region_name: us-west-2
     regexp: kubecf-bundle-v(.*).tgz
 
-
-# Pool resource with kube cluster information
-{{ range $_, $Backend := (ds "BACKEND").backend -}} # for all backends
+{{ range $_, $Backend := (ds "BACKEND").backend -}}
+{{- if ne $Backend "eks" -}}
+# {{$Backend}}: Pool resource serving kube clusters for this backend
 - name: {{$Backend}}-pool.kube-hosts
   type: pool
   source:
@@ -63,7 +62,10 @@ resources:
     private_key: ((github-private-key))
     branch: {{$Backend}}-kube-hosts
     pool: {{$Backend}}-kube-hosts
-{{end}}
+{{- else -}}
+# {{$Backend}}: Terraform based dynamic cluster creation, no pool
+{{- end -}}
+{{- end -}}
 
 {{ $pipelineName := .Env.PIPELINE }}
 
@@ -107,6 +109,40 @@ resources:
             export BACKEND=caasp4os
             export KUBECFG=$PWD/kubeconfig_$CLUSTER_NAME
             make kubeconfig
+` }}
+
+{{- $deploy_eks := `
+            # create buildfolder prepared for eks, dynamically create cluster
+            export BACKEND=eks
+            # AWS vars exported here so hijacking doesn't contain them in env
+            export AWS_ACCESS_KEY_ID='((aws-ci-chuller-access-key-id))'
+            export AWS_SECRET_ACCESS_KEY='((aws-ci-chuller-secret-access-key))'
+            export EKS_KEYPAIR=work-terraform
+            export EKS_CLUSTER_LABEL="{key = \"cap-ci-${CI_CONFIG}\"}"
+            pushd catapult
+            make k8s
+` }}
+
+{{- $tf_save := `
+            # collect and save build configuration, for teardown at end.
+            #
+            build_directory="build${BACKEND}"
+            tar cfz - "${build_directory}" > cluster-state.tgz
+            aws s3 cp cluster-state.tgz "s3://cap-ci-tf/ci-${CI_CONFIG}.tgz"
+` }}
+
+{{- $tf_restore := `
+            # pull and restore build configuration
+            #
+            aws s3 cp "s3://cap-ci-tf/ci-${CI_CONFIG}.tgz" cluster-state.tgz
+            tar xfz cluster-state.tgz
+            pushd catapult
+` }}
+
+{{- $tf_remove := `
+            # pull and restore build configuration
+            #
+            aws s3 rm "s3://cap-ci-tf/ci-${CI_CONFIG}.tgz"
 ` }}
 
 {{- $deploy := `
@@ -173,14 +209,18 @@ jobs:
   - get: s3.kubecf-bundle
     trigger: true
   - get: catapult
+{{- if ne $Backend "eks" }}
   - put: {{$Backend}}-pool.kube-hosts
     params: {acquire: true}
     timeout: 2m
+{{- end }}
   - task: deploy
     privileged: true
     timeout: 2h30m
+{{- if ne $Backend "eks" }}
     input_mapping:
       pool.kube-hosts: {{$Backend}}-pool.kube-hosts
+{{- end }}
     config:
       platform: linux
       image_resource:
@@ -190,7 +230,9 @@ jobs:
       inputs:
       - name: catapult
       - name: s3.kubecf-bundle
+{{- if ne $Backend "eks" }}
       - name: pool.kube-hosts
+{{- end }}
       params:
         BRAIN_VERBOSE: {{(ds "BRAIN_VERBOSE")}}
         BRAIN_INORDER: {{(ds "BRAIN_INORDER")}}
@@ -215,17 +257,21 @@ jobs:
         args:
           - -c
           - |
-            {{- print $obtain_kubeconfig }}
+            export CI_CONFIG="{{ $pipelineName }}-{{ $EiriniFlag }}-{{ $Backend }}-{{ $OptionsFlag }}"
             {{- if eq $Backend "caasp4" }}
+            {{- print $obtain_kubeconfig }}
             {{- print $import_caasp4 }}
             {{- end }}
             {{- if eq $Backend "eks" }}
-            {{- print $import_eks }}
+            {{- print $deploy_eks }}
+            {{- print $tf_save }}
             {{- end }}
             {{- if eq $Backend "gke" }}
+            {{- print $obtain_kubeconfig }}
             {{- print $import_gke }}
             {{- end }}
             {{- if eq $Backend "aks" }}
+            {{- print $obtain_kubeconfig }}
             {{- print $import_aks }}
             {{- end }}
             {{- print $deploy }}
@@ -234,16 +280,21 @@ jobs:
   serial_groups: [{{$EiriniFlag}}-{{$Backend}}-{{$OptionsFlag}}]
   public: false
   plan:
-  - get: catapult
-  - get: {{$Backend}}-pool.kube-hosts
+  - get: s3.kubecf-bundle
     passed:
     - deploy-{{ $EiriniFlag }}-{{ $Backend }}-{{ $OptionsFlag }}
     trigger: true
+  - get: catapult
+{{- if ne $Backend "eks" }}
+  - get: {{$Backend}}-pool.kube-hosts
+{{- end }}
   - task: test-{{$EiriniFlag}}
     privileged: true
     timeout: 1h30m
+{{- if ne $Backend "eks" }}
     input_mapping:
       pool.kube-hosts: {{$Backend}}-pool.kube-hosts
+{{- end }}
     config:
       platform: linux
       image_resource:
@@ -252,7 +303,9 @@ jobs:
           repository: splatform/catapult
       inputs:
       - name: catapult
+{{- if ne $Backend "eks" }}
       - name: pool.kube-hosts
+{{- end }}
       params:
         QUIET_OUTPUT: true
         DOWNLOAD_CATAPULT_DEPS: false
@@ -276,15 +329,19 @@ jobs:
           - |
             {{- print $obtain_kubeconfig }}
             {{- if eq $Backend "caasp4" }}
+            {{- print $obtain_kubeconfig }}
             {{- print $import_caasp4 }}
             {{- end }}
             {{- if eq $Backend "eks" }}
+            {{- print $obtain_kubeconfig }}
             {{- print $import_eks }}
             {{- end }}
             {{- if eq $Backend "gke" }}
+            {{- print $obtain_kubeconfig }}
             {{- print $import_gke }}
             {{- end }}
             {{- if eq $Backend "aks" }}
+            {{- print $obtain_kubeconfig }}
             {{- print $import_aks }}
             {{- end }}
             {{- print $test }}
@@ -293,16 +350,21 @@ jobs:
   serial_groups: [{{$EiriniFlag}}-{{$Backend}}-{{$OptionsFlag}}]
   public: false
   plan:
-  - get: catapult
-  - get: {{$Backend}}-pool.kube-hosts
+  - get: s3.kubecf-bundle
     passed:
     - smoke-tests-{{$EiriniFlag}}-{{$Backend}}-{{$OptionsFlag}}
     trigger: true
+  - get: catapult
+{{- if ne $Backend "eks" }}
+  - get: {{$Backend}}-pool.kube-hosts
+{{- end }}
   - task: test-{{$EiriniFlag}}
     privileged: true
     timeout: 5h30m
+{{- if ne $Backend "eks" }}
     input_mapping:
       pool.kube-hosts: {{$Backend}}-pool.kube-hosts
+{{- end }}
     config:
       platform: linux
       image_resource:
@@ -311,7 +373,9 @@ jobs:
           repository: splatform/catapult
       inputs:
       - name: catapult
+{{- if ne $Backend "eks" }}
       - name: pool.kube-hosts
+{{- end }}
       params:
         QUIET_OUTPUT: true
         DOWNLOAD_CATAPULT_DEPS: false
@@ -333,17 +397,20 @@ jobs:
         args:
           - -c
           - |
-            {{- print $obtain_kubeconfig}}
             {{- if eq $Backend "caasp4" }}
+            {{- print $obtain_kubeconfig}}
             {{- print $import_caasp4 }}
             {{- end }}
             {{- if eq $Backend "eks" }}
+            {{- print $obtain_kubeconfig}}
             {{- print $import_eks }}
             {{- end }}
             {{- if eq $Backend "gke" }}
+            {{- print $obtain_kubeconfig}}
             {{- print $import_gke }}
             {{- end }}
             {{- if eq $Backend "aks" }}
+            {{- print $obtain_kubeconfig}}
             {{- print $import_aks }}
             {{- end }}
             {{- print $test }}
@@ -352,16 +419,21 @@ jobs:
   serial_groups: [{{$EiriniFlag}}-{{$Backend}}-{{$OptionsFlag}}]
   public: false
   plan:
-  - get: catapult
-  - get: {{$Backend}}-pool.kube-hosts
+  - get: s3.kubecf-bundle
     passed:
     - cf-acceptance-tests-{{$EiriniFlag}}-{{$Backend}}-{{$OptionsFlag}}
     trigger: true
+  - get: catapult
+{{- if ne $Backend "eks" }}
+  - get: {{$Backend}}-pool.kube-hosts
+{{- end }}
   - task: test-{{$EiriniFlag}}
     privileged: true
     timeout: 5h30m
+{{- if ne $Backend "eks" }}
     input_mapping:
       pool.kube-hosts: {{$Backend}}-pool.kube-hosts
+{{- end }}
     config:
       platform: linux
       image_resource:
@@ -370,7 +442,9 @@ jobs:
           repository: splatform/catapult
       inputs:
       - name: catapult
+{{- if ne $Backend "eks" }}
       - name: pool.kube-hosts
+{{- end }}
       params:
         QUIET_OUTPUT: true
         DOWNLOAD_CATAPULT_DEPS: false
@@ -392,17 +466,20 @@ jobs:
         args:
           - -c
           - |
-            {{- print $obtain_kubeconfig }}
             {{- if eq $Backend "caasp4" }}
+            {{- print $obtain_kubeconfig }}
             {{- print $import_caasp4 }}
             {{- end }}
             {{- if eq $Backend "eks" }}
+            {{- print $obtain_kubeconfig }}
             {{- print $import_eks }}
             {{- end }}
             {{- if eq $Backend "gke" }}
+            {{- print $obtain_kubeconfig }}
             {{- print $import_gke }}
             {{- end }}
             {{- if eq $Backend "aks" }}
+            {{- print $obtain_kubeconfig }}
             {{- print $import_aks }}
             {{- end }}
             {{- print $test }}
@@ -411,16 +488,21 @@ jobs:
   serial_groups: [{{$EiriniFlag}}-{{$Backend}}-{{$OptionsFlag}}]
   public: false
   plan:
-  - get: catapult
-  - get: {{$Backend}}-pool.kube-hosts
+  - get: s3.kubecf-bundle
     passed:
     - sync-integration-tests-{{$EiriniFlag}}-{{$Backend}}-{{$OptionsFlag}}
     trigger: true
+  - get: catapult
+{{- if ne $Backend "eks" }}
+  - get: {{$Backend}}-pool.kube-hosts
+{{- end }}
   - task: test-{{$EiriniFlag}}
     privileged: true
     timeout: 5h30m
+{{- if ne $Backend "eks" }}
     input_mapping:
       pool.kube-hosts: {{$Backend}}-pool.kube-hosts
+{{- end }}
     config:
       platform: linux
       image_resource:
@@ -429,7 +511,9 @@ jobs:
           repository: splatform/catapult
       inputs:
       - name: catapult
+{{- if ne $Backend "eks" }}
       - name: pool.kube-hosts
+{{- end }}
       params:
         QUIET_OUTPUT: true
         DOWNLOAD_CATAPULT_DEPS: false
@@ -451,17 +535,20 @@ jobs:
         args:
           - -c
           - |
-            {{- print $obtain_kubeconfig }}
             {{- if eq $Backend "caasp4" }}
+            {{- print $obtain_kubeconfig }}
             {{- print $import_caasp4 }}
             {{- end }}
             {{- if eq $Backend "eks" }}
+            {{- print $obtain_kubeconfig }}
             {{- print $import_eks }}
             {{- end }}
             {{- if eq $Backend "gke" }}
+            {{- print $obtain_kubeconfig }}
             {{- print $import_gke }}
             {{- end }}
             {{- if eq $Backend "aks" }}
+            {{- print $obtain_kubeconfig }}
             {{- print $import_aks }}
             {{- end }}
             {{- print $test }}
@@ -471,17 +558,20 @@ jobs:
   public: false
   plan:
   - get: s3.kubecf-bundle
-    trigger: false
-  - get: catapult
-  - get: {{$Backend}}-pool.kube-hosts
     passed:
     - cf-acceptance-tests-brain-{{$EiriniFlag}}-{{$Backend}}-{{$OptionsFlag}}
-    trigger: true
+    trigger: false
+  - get: catapult
+{{- if ne $Backend "eks" }}
+  - get: {{$Backend}}-pool.kube-hosts
+{{- end }}
   - task: upgrade-{{$EiriniFlag}}
     privileged: true
     timeout: 5h30m
+{{- if ne $Backend "eks" }}
     input_mapping:
       pool.kube-hosts: {{$Backend}}-pool.kube-hosts
+{{- end }}
     config:
       platform: linux
       image_resource:
@@ -491,7 +581,9 @@ jobs:
       inputs:
       - name: catapult
       - name: s3.kubecf-bundle
+{{- if ne $Backend "eks" }}
       - name: pool.kube-hosts
+{{- end }}
       params:
         QUIET_OUTPUT: true
         DOWNLOAD_CATAPULT_DEPS: false
@@ -515,17 +607,20 @@ jobs:
         args:
           - -c
           - |
-            {{- print $obtain_kubeconfig }}
             {{- if eq $Backend "caasp4" }}
+            {{- print $obtain_kubeconfig }}
             {{- print $import_caasp4 }}
             {{- end }}
             {{- if eq $Backend "eks" }}
+            {{- print $obtain_kubeconfig }}
             {{- print $import_eks }}
             {{- end }}
             {{- if eq $Backend "gke" }}
+            {{- print $obtain_kubeconfig }}
             {{- print $import_gke }}
             {{- end }}
             {{- if eq $Backend "aks" }}
+            {{- print $obtain_kubeconfig }}
             {{- print $import_aks }}
             {{- end }}
             {{- print $upgrade }}
@@ -534,16 +629,21 @@ jobs:
   serial_groups: [{{$EiriniFlag}}-{{$Backend}}-{{$OptionsFlag}}]
   public: false
   plan:
-  - get: catapult
-  - get: {{$Backend}}-pool.kube-hosts
+  - get: s3.kubecf-bundle
     passed:
     - upgrade-{{$EiriniFlag}}-{{$Backend}}-{{$OptionsFlag}}
     trigger: true
+  - get: catapult
+{{- if ne $Backend "eks" }}
+  - get: {{$Backend}}-pool.kube-hosts
+{{- end }}
   - task: stratos-{{$EiriniFlag}}
     privileged: true
     timeout: 5h30m
+{{- if ne $Backend "eks" }}
     input_mapping:
       pool.kube-hosts: {{$Backend}}-pool.kube-hosts
+{{- end }}
     config:
       platform: linux
       image_resource:
@@ -552,7 +652,9 @@ jobs:
           repository: splatform/catapult
       inputs:
       - name: catapult
+{{- if ne $Backend "eks" }}
       - name: pool.kube-hosts
+{{- end }}
       params:
         QUIET_OUTPUT: true
         DOWNLOAD_CATAPULT_DEPS: false
@@ -574,17 +676,20 @@ jobs:
         args:
           - -c
           - |
-            {{- print $obtain_kubeconfig }}
             {{- if eq $Backend "caasp4" }}
+            {{- print $obtain_kubeconfig }}
             {{- print $import_caasp4 }}
             {{- end }}
             {{- if eq $Backend "eks" }}
+            {{- print $obtain_kubeconfig }}
             {{- print $import_eks }}
             {{- end }}
             {{- if eq $Backend "gke" }}
+            {{- print $obtain_kubeconfig }}
             {{- print $import_gke }}
             {{- end }}
             {{- if eq $Backend "aks" }}
+            {{- print $obtain_kubeconfig }}
             {{- print $import_aks }}
             {{- end }}
             {{- print $stratos }}

--- a/cap-ci/pipeline.template
+++ b/cap-ci/pipeline.template
@@ -8,10 +8,19 @@ groups:
 {{ range $_, $EiriniFlag := (ds "EIRINI").eirini -}} # for eirini
 {{ range $_, $OptionsFlag := (ds "OPTIONS").options -}} # for options
     - {{$Jobs}}-{{$EiriniFlag}}-{{$Backend}}-{{$OptionsFlag}}
-{{ end }} # end jobs
 {{ end }} # end eirini
 {{ end }} # end options
+{{ end }} # end jobs
+# teardown jobs only for backends using cap-terraform to dynamically create a cluster: Only EKS
+{{- if eq $Backend "eks" }}
+{{ range $_, $EiriniFlag := (ds "EIRINI").eirini -}} # for eirini
+{{ range $_, $OptionsFlag := (ds "OPTIONS").options -}} # for options
+    - teardown-{{$EiriniFlag}}-{{$Backend}}-{{$OptionsFlag}}
+{{ end }} # end eirini
+{{ end }} # end options
+{{- end}}
 {{ end }} # end backend
+
 - name: ALL
   jobs:
 {{ range $_, $Backend := (ds "BACKEND").backend -}} # for all backends
@@ -19,9 +28,17 @@ groups:
 {{ range $_, $EiriniFlag := (ds "EIRINI").eirini -}} # for eirini
 {{ range $_, $OptionsFlag := (ds "OPTIONS").options -}} # for options
     - {{$Jobs}}-{{$EiriniFlag}}-{{$Backend}}-{{$OptionsFlag}}
-{{ end }} # end jobs
 {{ end }} # end eirini
 {{ end }} # end options
+{{ end }} # end jobs
+# teardown jobs only for backends using cap-terraform to dynamically create a cluster: Only EKS
+{{- if eq $Backend "eks" }}
+{{ range $_, $EiriniFlag := (ds "EIRINI").eirini -}} # for eirini
+{{ range $_, $OptionsFlag := (ds "OPTIONS").options -}} # for options
+    - teardown-{{$EiriniFlag}}-{{$Backend}}-{{$OptionsFlag}}
+{{ end }} # end eirini
+{{ end }} # end options
+{{- end}}
 {{ end }} # end backend
 
 resource_types:
@@ -153,6 +170,15 @@ resources:
             export DOCKER_ORG=cap-staging
             export QUIET_OUTPUT=true
             make scf && make scf-login # ensure scf is there
+` }}
+
+{{- $teardown := `
+            # tear kubecf and cluster down
+            export SCF_OPERATOR=true
+            export DOCKER_ORG=cap-staging
+            export QUIET_OUTPUT=true
+            make scf-clean
+            make clean
 ` }}
 
 {{- $test := `
@@ -693,6 +719,52 @@ jobs:
             {{- print $import_aks }}
             {{- end }}
             {{- print $stratos }}
+
+{{- if eq $Backend "eks" }}
+- name: teardown-{{$EiriniFlag}}-{{$Backend}}-{{$OptionsFlag}}
+  serial_groups: [{{$EiriniFlag}}-{{$Backend}}-{{$OptionsFlag}}]
+  public: false
+  plan:
+  - get: s3.kubecf-bundle
+    passed:
+    - deploy-{{ $EiriniFlag }}-{{ $Backend }}-{{ $OptionsFlag }}
+  - get: catapult
+  - task: teardown-{{$EiriniFlag}}
+    privileged: true
+    timeout: 1h30m
+    config:
+      platform: linux
+      image_resource:
+        type: registry-image
+        source:
+          repository: splatform/catapult
+      inputs:
+      - name: catapult
+      params:
+        QUIET_OUTPUT: true
+        DOWNLOAD_CATAPULT_DEPS: false
+        DEFAULT_STACK: cflinuxfs3
+{{- if eq $EiriniFlag "eirini" }}
+        ENABLE_EIRINI: true
+{{ else }}
+        ENABLE_EIRINI: false
+{{- end }}
+{{- if eq $OptionsFlag "ha" }}
+        HA: true
+{{- end }}
+{{- if eq $OptionsFlag "all" }}
+{{- print $allbells }}
+{{- end }}
+      run:
+        path: "/bin/bash"
+        args:
+          - -c
+          - |
+            export CI_CONFIG="{{ $pipelineName }}-{{ $EiriniFlag }}-{{ $Backend }}-{{ $OptionsFlag }}"
+            {{- print $tf_restore }}
+            {{- print $teardown }}
+            {{- print $tf_remove }}
+{{- end }}
 
 {{ end }} # end eirini
 {{ end }} # end options


### PR DESCRIPTION
:warning: :construction: WIP :construction: :warning: 
(Messed up, wanted to make a draft PR, was too fast in hitting the button).

See https://jira.suse.com/browse/CAP-1395
The draft prs in `cap-terraform` and `catapult` are superfluous.

Manual testing so far:
- cluster setup :heavy_check_mark: 
- cluster state save  :heavy_check_mark:  (Might be too early actually)
- kubecf setup  :heavy_check_mark: 
- kubecf access :boom: (DNS config is not good for working with public cloud)

Completely untested: Teardown code and job.
