### PR TITLE
Remove privileged from helm charts ci

### DIFF
--- a/cap-helm-charts-ci/pipeline.yaml.gomplate
+++ b/cap-helm-charts-ci/pipeline.yaml.gomplate
@@ -34,7 +34,6 @@ jobs:
     - get: helm-charts-repo
   - do:
     - task: create_pr
-      privileged: true
       params:
         GITHUB_TOKEN:  {{ index (datasource "concourse-secrets") "github-access-token" }}
         GITHUB_PRIVATE_KEY:  {{ index (datasource "concourse-secrets") "github-private-key" | data.ToYAML | indent 7 }}


### PR DESCRIPTION
Analogous to cloudfoundry-incubator/kubecf#885

There is a performance hit of 20mins on startup, see:
concourse/concourse#4332