### PR TITLE
Cleanup catapult vars and make calls in cap-ci/

### DIFF
--- a/cap-ci/pipeline.template
+++ b/cap-ci/pipeline.template
@@ -317,11 +317,6 @@ jobs:
             BACKEND: {{ $backend }}
             QUIET_OUTPUT: true
             DOWNLOAD_CATAPULT_DEPS: false
-            {{- if eq $scheduler "eirini" }}
-            ENABLE_EIRINI: true
-            {{ else }}
-            ENABLE_EIRINI: false
-            {{- end }}
           run:
             path: "/bin/bash"
             args:
@@ -466,11 +461,6 @@ jobs:
             BACKEND: {{ $backend }}
             QUIET_OUTPUT: true
             DOWNLOAD_CATAPULT_DEPS: false
-            {{- if eq $scheduler "eirini" }}
-            ENABLE_EIRINI: true
-            {{ else }}
-            ENABLE_EIRINI: false
-            {{- end }}
           run:
             path: "/bin/bash"
             args:
@@ -535,17 +525,6 @@ jobs:
       params:
         QUIET_OUTPUT: true
         DOWNLOAD_CATAPULT_DEPS: false
-{{- if eq $scheduler "eirini" }}
-        ENABLE_EIRINI: true
-{{ else }}
-        ENABLE_EIRINI: false
-{{- end }}
-{{- if eq $option "ha" }}
-        HA: true
-{{- end }}
-{{- if eq $option "all" }}
-{{- print $allbells }}
-{{- end }}
         TEST_SUITE: smokes
       run:
         path: "/bin/bash"
@@ -590,11 +569,6 @@ jobs:
             BACKEND: {{ $backend }}
             QUIET_OUTPUT: true
             DOWNLOAD_CATAPULT_DEPS: false
-            {{- if eq $scheduler "eirini" }}
-            ENABLE_EIRINI: true
-            {{ else }}
-            ENABLE_EIRINI: false
-            {{- end }}
           run:
             path: "/bin/bash"
             args:
@@ -659,17 +633,6 @@ jobs:
       params:
         QUIET_OUTPUT: true
         DOWNLOAD_CATAPULT_DEPS: false
-{{- if eq $scheduler "eirini" }}
-        ENABLE_EIRINI: true
-{{ else }}
-        ENABLE_EIRINI: false
-{{- end }}
-{{- if eq $option "ha" }}
-        HA: true
-{{- end }}
-{{- if eq $option "all" }}
-{{- print $allbells }}
-{{- end }}
         TEST_SUITE: brain
       run:
         path: "/bin/bash"
@@ -714,11 +677,6 @@ jobs:
             BACKEND: {{ $backend }}
             QUIET_OUTPUT: true
             DOWNLOAD_CATAPULT_DEPS: false
-            {{- if eq $scheduler "eirini" }}
-            ENABLE_EIRINI: true
-            {{ else }}
-            ENABLE_EIRINI: false
-            {{- end }}
           run:
             path: "/bin/bash"
             args:
@@ -783,17 +741,6 @@ jobs:
       params:
         QUIET_OUTPUT: true
         DOWNLOAD_CATAPULT_DEPS: false
-{{- if eq $scheduler "eirini" }}
-        ENABLE_EIRINI: true
-{{ else }}
-        ENABLE_EIRINI: false
-{{- end }}
-{{- if eq $option "ha" }}
-        HA: true
-{{- end }}
-{{- if eq $option "all" }}
-{{- print $allbells }}
-{{- end }}
         TEST_SUITE: cats
       run:
         path: "/bin/bash"
@@ -838,11 +785,6 @@ jobs:
             BACKEND: {{ $backend }}
             QUIET_OUTPUT: true
             DOWNLOAD_CATAPULT_DEPS: false
-            {{- if eq $scheduler "eirini" }}
-            ENABLE_EIRINI: true
-            {{ else }}
-            ENABLE_EIRINI: false
-            {{- end }}
           run:
             path: "/bin/bash"
             args:
@@ -907,17 +849,6 @@ jobs:
       params:
         QUIET_OUTPUT: true
         DOWNLOAD_CATAPULT_DEPS: false
-{{- if eq $scheduler "eirini" }}
-        ENABLE_EIRINI: true
-{{ else }}
-        ENABLE_EIRINI: false
-{{- end }}
-{{- if eq $option "ha" }}
-        HA: true
-{{- end }}
-{{- if eq $option "all" }}
-{{- print $allbells }}
-{{- end }}
         TEST_SUITE: sits
       run:
         path: "/bin/bash"
@@ -962,11 +893,6 @@ jobs:
             BACKEND: {{ $backend }}
             QUIET_OUTPUT: true
             DOWNLOAD_CATAPULT_DEPS: false
-            {{- if eq $scheduler "eirini" }}
-            ENABLE_EIRINI: true
-            {{ else }}
-            ENABLE_EIRINI: false
-            {{- end }}
           run:
             path: "/bin/bash"
             args:
@@ -1034,17 +960,6 @@ jobs:
       params:
         QUIET_OUTPUT: true
         DOWNLOAD_CATAPULT_DEPS: false
-{{- if eq $scheduler "eirini" }}
-        ENABLE_EIRINI: true
-{{ else }}
-        ENABLE_EIRINI: false
-{{- end }}
-{{- if eq $option "ha" }}
-        HA: true
-{{- end }}
-{{- if eq $option "all" }}
-{{- print $allbells }}
-{{- end }}
         TEST_SUITE: cats
         TEST_SUITE: cats
         BACKEND: {{ $backend }}
@@ -1091,11 +1006,6 @@ jobs:
             BACKEND: {{ $backend }}
             QUIET_OUTPUT: true
             DOWNLOAD_CATAPULT_DEPS: false
-            {{- if eq $scheduler "eirini" }}
-            ENABLE_EIRINI: true
-            {{ else }}
-            ENABLE_EIRINI: false
-            {{- end }}
           run:
             path: "/bin/bash"
             args:
@@ -1164,18 +1074,6 @@ jobs:
       params:
         QUIET_OUTPUT: true
         DOWNLOAD_CATAPULT_DEPS: false
-{{- if eq $scheduler "eirini" }}
-        ENABLE_EIRINI: true
-{{ else }}
-        ENABLE_EIRINI: false
-{{- end }}
-{{- if eq $option "ha" }}
-        HA: true
-{{- end }}
-{{- if eq $option "all" }}
-{{- print $allbells }}
-{{- end }}
-        TEST_SUITE: cats
       run:
         path: "/bin/bash"
         args:
@@ -1219,11 +1117,6 @@ jobs:
             BACKEND: {{ $backend }}
             QUIET_OUTPUT: true
             DOWNLOAD_CATAPULT_DEPS: false
-            {{- if eq $scheduler "eirini" }}
-            ENABLE_EIRINI: true
-            {{ else }}
-            ENABLE_EIRINI: false
-            {{- end }}
           run:
             path: "/bin/bash"
             args:

--- a/cap-ci/pipeline.template
+++ b/cap-ci/pipeline.template
@@ -277,7 +277,6 @@ jobs:
       params:
         BACKEND: {{ $backend }}
         QUIET_OUTPUT: true
-        DEFAULT_STACK: cflinuxfs3
         DOWNLOAD_CATAPULT_DEPS: false
       run:
         path: "/bin/bash"
@@ -317,7 +316,6 @@ jobs:
           params:
             BACKEND: {{ $backend }}
             QUIET_OUTPUT: true
-            DEFAULT_STACK: cflinuxfs3
             DOWNLOAD_CATAPULT_DEPS: false
             {{- if eq $scheduler "eirini" }}
             ENABLE_EIRINI: true
@@ -414,7 +412,6 @@ jobs:
         CATS_TIMEOUT_SCALE: {{ index $config.cats "timeout-scale" }}
         QUIET_OUTPUT: true
         DOWNLOAD_CATAPULT_DEPS: false
-        DEFAULT_STACK: cflinuxfs3
 {{- if eq $scheduler "eirini" }}
         ENABLE_EIRINI: true
 {{ else }}
@@ -468,7 +465,6 @@ jobs:
           params:
             BACKEND: {{ $backend }}
             QUIET_OUTPUT: true
-            DEFAULT_STACK: cflinuxfs3
             DOWNLOAD_CATAPULT_DEPS: false
             {{- if eq $scheduler "eirini" }}
             ENABLE_EIRINI: true
@@ -539,7 +535,6 @@ jobs:
       params:
         QUIET_OUTPUT: true
         DOWNLOAD_CATAPULT_DEPS: false
-        DEFAULT_STACK: cflinuxfs3
 {{- if eq $scheduler "eirini" }}
         ENABLE_EIRINI: true
 {{ else }}
@@ -594,7 +589,6 @@ jobs:
           params:
             BACKEND: {{ $backend }}
             QUIET_OUTPUT: true
-            DEFAULT_STACK: cflinuxfs3
             DOWNLOAD_CATAPULT_DEPS: false
             {{- if eq $scheduler "eirini" }}
             ENABLE_EIRINI: true
@@ -665,7 +659,6 @@ jobs:
       params:
         QUIET_OUTPUT: true
         DOWNLOAD_CATAPULT_DEPS: false
-        DEFAULT_STACK: cflinuxfs3
 {{- if eq $scheduler "eirini" }}
         ENABLE_EIRINI: true
 {{ else }}
@@ -720,7 +713,6 @@ jobs:
           params:
             BACKEND: {{ $backend }}
             QUIET_OUTPUT: true
-            DEFAULT_STACK: cflinuxfs3
             DOWNLOAD_CATAPULT_DEPS: false
             {{- if eq $scheduler "eirini" }}
             ENABLE_EIRINI: true
@@ -791,7 +783,6 @@ jobs:
       params:
         QUIET_OUTPUT: true
         DOWNLOAD_CATAPULT_DEPS: false
-        DEFAULT_STACK: cflinuxfs3
 {{- if eq $scheduler "eirini" }}
         ENABLE_EIRINI: true
 {{ else }}
@@ -846,7 +837,6 @@ jobs:
           params:
             BACKEND: {{ $backend }}
             QUIET_OUTPUT: true
-            DEFAULT_STACK: cflinuxfs3
             DOWNLOAD_CATAPULT_DEPS: false
             {{- if eq $scheduler "eirini" }}
             ENABLE_EIRINI: true
@@ -917,7 +907,6 @@ jobs:
       params:
         QUIET_OUTPUT: true
         DOWNLOAD_CATAPULT_DEPS: false
-        DEFAULT_STACK: cflinuxfs3
 {{- if eq $scheduler "eirini" }}
         ENABLE_EIRINI: true
 {{ else }}
@@ -972,7 +961,6 @@ jobs:
           params:
             BACKEND: {{ $backend }}
             QUIET_OUTPUT: true
-            DEFAULT_STACK: cflinuxfs3
             DOWNLOAD_CATAPULT_DEPS: false
             {{- if eq $scheduler "eirini" }}
             ENABLE_EIRINI: true
@@ -1046,7 +1034,6 @@ jobs:
       params:
         QUIET_OUTPUT: true
         DOWNLOAD_CATAPULT_DEPS: false
-        DEFAULT_STACK: cflinuxfs3
 {{- if eq $scheduler "eirini" }}
         ENABLE_EIRINI: true
 {{ else }}
@@ -1103,7 +1090,6 @@ jobs:
           params:
             BACKEND: {{ $backend }}
             QUIET_OUTPUT: true
-            DEFAULT_STACK: cflinuxfs3
             DOWNLOAD_CATAPULT_DEPS: false
             {{- if eq $scheduler "eirini" }}
             ENABLE_EIRINI: true
@@ -1178,7 +1164,6 @@ jobs:
       params:
         QUIET_OUTPUT: true
         DOWNLOAD_CATAPULT_DEPS: false
-        DEFAULT_STACK: cflinuxfs3
 {{- if eq $scheduler "eirini" }}
         ENABLE_EIRINI: true
 {{ else }}
@@ -1233,7 +1218,6 @@ jobs:
           params:
             BACKEND: {{ $backend }}
             QUIET_OUTPUT: true
-            DEFAULT_STACK: cflinuxfs3
             DOWNLOAD_CATAPULT_DEPS: false
             {{- if eq $scheduler "eirini" }}
             ENABLE_EIRINI: true

--- a/cap-ci/pipeline.template
+++ b/cap-ci/pipeline.template
@@ -958,11 +958,10 @@ jobs:
       - name: s3.kubecf-bundle
       - name: pool.kube-hosts
       params:
+        BACKEND: {{ $backend }}
         QUIET_OUTPUT: true
         DOWNLOAD_CATAPULT_DEPS: false
         TEST_SUITE: cats
-        TEST_SUITE: cats
-        BACKEND: {{ $backend }}
       run:
         path: "/bin/bash"
         args:

--- a/cap-ci/pipeline.template
+++ b/cap-ci/pipeline.template
@@ -190,7 +190,6 @@ resources:
                 # Attention: PWD = ___/catapult here
                 # deploy kubecf from chart
                 export SCF_CHART="$(readlink -f ../s3.kubecf-bundle/*.tgz)"
-                export SCF_TESTGROUP=true
                 export SCF_OPERATOR=true
                 export DOCKER_ORG=cap-staging
                 export QUIET_OUTPUT=true
@@ -204,7 +203,6 @@ resources:
                 # See: https://github.com/SUSE/catapult/wiki/Running-SCF-tests#kubecf
                 export KUBECF_TEST_SUITE="${TEST_SUITE:-smokes}"
                 export KUBECF_NAMESPACE="scf"
-                export SCF_TESTGROUP=true
                 export QUIET_OUTPUT=true
                 env | sort | sed -e 's|^|CONFIGURATION: |'
                 make tests-kubecf
@@ -214,7 +212,6 @@ resources:
                 # Attention: PWD = ____/catapult here
                 # obtain scf-config-values.yaml for stratos
                 export QUIET_OUTPUT=true
-                export SCF_TESTGROUP=true
                 export SCF_OPERATOR=true
                 export DOCKER_ORG=cap-staging
                 make scf-gen-config

--- a/cap-ci/pipeline.template
+++ b/cap-ci/pipeline.template
@@ -407,17 +407,17 @@ jobs:
         CATS_TIMEOUT_SCALE: {{ index $config.cats "timeout-scale" }}
         QUIET_OUTPUT: true
         DOWNLOAD_CATAPULT_DEPS: false
-{{- if eq $scheduler "eirini" }}
+        {{- if eq $scheduler "eirini" }}
         ENABLE_EIRINI: true
-{{ else }}
+        {{ else }}
         ENABLE_EIRINI: false
-{{- end }}
-{{- if eq $option "ha" }}
+        {{- end }}
+        {{- if eq $option "ha" }}
         HA: true
-{{- end }}
-{{- if eq $option "all" }}
-{{- print $allbells }}
-{{- end }}
+        {{- end }}
+        {{- if eq $option "all" }}
+        {{- print $allbells }}
+        {{- end }}
       run:
         path: "/bin/bash"
         args:

--- a/cap-ci/pipeline.template
+++ b/cap-ci/pipeline.template
@@ -139,7 +139,6 @@ resources:
                 if [[ ${BACKEND} == "gke" ]]; then
                     printf "%s" '((gke-key-json))' > $PWD/gke-key.json
                     export GKE_CRED_JSON=$PWD/gke-key.json
-                    export SCF_OPERATOR=true
                     make clean
                 fi
 ` }}
@@ -190,11 +189,10 @@ resources:
                 # Attention: PWD = ___/catapult here
                 # deploy kubecf from chart
                 export SCF_CHART="$(readlink -f ../s3.kubecf-bundle/*.tgz)"
-                export SCF_OPERATOR=true
                 export DOCKER_ORG=cap-staging
                 export QUIET_OUTPUT=true
                 env | sort | sed -e 's|^|CONFIGURATION: |'
-                make scf && make scf-login # ensure scf is there
+                make kubecf && make kubecf-login # ensure scf is there
 ` }}
 
 {{- $test := `
@@ -212,9 +210,8 @@ resources:
                 # Attention: PWD = ____/catapult here
                 # obtain scf-config-values.yaml for stratos
                 export QUIET_OUTPUT=true
-                export SCF_OPERATOR=true
                 export DOCKER_ORG=cap-staging
-                make scf-gen-config
+                make kubecf-gen-config
                 # deploy stratos console & metrics
                 export STRATOS_CHART="$(readlink -f ../helm-chart.stratos-chart/*.tgz)"
                 export METRICS_CHART="$(readlink -f ../helm-chart.stratos-metrics-chart/*.tgz)"
@@ -227,13 +224,12 @@ resources:
                 # Attention: PWD = ___/catapult here
                 # upgrade kubecf
                 export SCF_CHART="$(readlink -f ../s3.kubecf-bundle/*.tgz)"
-                export SCF_OPERATOR=true
                 export DOCKER_ORG=cap-staging
                 export QUIET_OUTPUT=true
                 env | sort | sed -e 's|^|CONFIGURATION: |'
-                make scf-chart # this takes the same chart as the deploy step for now
-                make scf-gen-config
-                make scf-upgrade
+                make kubecf-chart # this takes the same chart as the deploy step for now
+                make kubecf-gen-config
+                make kubecf-upgrade
 ` }}
 
 {{- $allbells := `


### PR DESCRIPTION
This PR:
* Removes a bunch of uneeded env vars that we found when debugging an AKS deployment
* Removes DEFAULT_STACK=cflinuxfs3 for eirini, as newer kubecfs will not need it. See cloudfoundry/cf-smoke-tests#61
* Switches catapult calls from `make scf*` to `make kubecf*`