### PR TITLE
Rename {cap-release,cap-pre-release}.yaml.tmpl to .yaml

### DIFF
--- a/cap-ci/cap-pre-release.yaml
+++ b/cap-ci/cap-pre-release.yaml
@@ -1,4 +1,3 @@
-{{ define "config" }}
 workertags:
   # caasp4: suse-internal
 
@@ -47,7 +46,6 @@ cats:
   flake-attempts: 5
   timeout-scale: "3.0"
 s3:
-  bucket: cap-release-artifacts
-  regexp: CAP-(.*).tgz
-  region: us-east-1
-{{ end }}
+  bucket: kubecf
+  region: us-west-2
+  regexp: kubecf-bundle-v(.*).tgz

--- a/cap-ci/cap-release.yaml
+++ b/cap-ci/cap-release.yaml
@@ -1,4 +1,3 @@
-{{ define "config" }}
 workertags:
   # caasp4: suse-internal
 
@@ -47,7 +46,6 @@ cats:
   flake-attempts: 5
   timeout-scale: "3.0"
 s3:
-  bucket: kubecf
-  region: us-west-2
-  regexp: kubecf-bundle-v(.*).tgz
-{{ end }}
+  bucket: cap-release-artifacts
+  regexp: CAP-(.*).tgz
+  region: us-east-1

--- a/cap-ci/create_pipeline.sh
+++ b/cap-ci/create_pipeline.sh
@@ -37,14 +37,13 @@ else
             exit 1
         fi
     fi
-    if test -f "${PIPELINE}".yaml.tmpl; then
-        pipeline_config=${PIPELINE}.yaml.tmpl
+    if test -f "${PIPELINE}".yaml; then
+        pipeline_config=${PIPELINE}.yaml
     else
-        echo "Config file ${PIPELINE}.yaml.tmpl doesn't exist."
+        echo "Config file ${PIPELINE}.yaml doesn't exist."
         usage
         exit 1
     fi
-    
 fi
 
 fly_args=(
@@ -54,7 +53,7 @@ fly_args=(
 )
 
 # space-separated paths to template files and directories which contain template files
-template_paths="${pipeline_config} scripts jobs common"
+template_paths="scripts jobs common"
 templates=$(find ${template_paths} -type f -exec echo "--template="{} \;)
 pipeline_file=${3:-pipeline.yaml.tmpl}
 
@@ -69,7 +68,7 @@ else
 fi
 
 # Push a new pipeline, or update an existing one
-fly "${fly_args[@]}" --config <(gomplate --verbose ${templates} --file "${pipeline_file}")
+fly "${fly_args[@]}" --config <(gomplate --verbose --datasource config="${pipeline_config}" "${templates}" --file "${pipeline_file}")
 
 # If the pipeline being pushed was a *new* pipeline, pause all the 'initial' jobs (jobs without 'passed:' dependencies)
 # Important caveat: If a pipeline is updated to add new targets, the new initial jobs will *not* be paused

--- a/cap-ci/pipeline.yaml.tmpl
+++ b/cap-ci/pipeline.yaml.tmpl
@@ -1,5 +1,5 @@
 ---
-{{- $config := tmpl.Exec "config" | data.YAML -}}
+{{- $config := (datasource "config") }}
 
 {{- /* Iterate over config jobs_enabled and jobs to get ordered array of enabled jobs */ -}}
 {{- define "jobs_ordered" -}}


### PR DESCRIPTION
This allows for linting and easy editor highlighting, etc, as there's no need to
have them as templates; they are config files afterall.

Load the config context in the "config" variable containing the context from the
"config" datasource. It would be possible to load the config as a '.' context,
but the context is lost when in "range" or "with", and would need to be
addressed with $.key, which seems less clear than $config.key as we have with
the datasource.