### PR TITLE
Adding pre and post upgrade smoke tests jobs.

### DIFF
--- a/cap-ci/jobs/post-upgrade-smoke-tests.tmpl
+++ b/cap-ci/jobs/post-upgrade-smoke-tests.tmpl
@@ -1,0 +1,58 @@
+{{ define "jobs_post-upgrade-smoke-tests" }}
+- name: post-upgrade-smoke-tests-{{ .scheduler }}-{{ .backend }}-{{ .avail }}
+  serial_groups: [{{ .scheduler }}-{{ .backend }}-{{ .avail }}]
+  public: false
+  plan:
+  - get: catapult
+  - get: {{ .backend }}-pool.kube-hosts
+    {{- if ne .position 0 }}
+    passed:
+    - {{ index .jobs_enabled (sub .position 1) }}-{{ .scheduler }}-{{ .backend }}-{{ .avail }}
+    {{- end }}
+    trigger: true
+  {{- if index .jobs "deploy-k8s" }}
+  - get: tfstate-pool
+    {{- if ne .position 0 }}
+    passed:
+    - {{ index .jobs_enabled (sub .position 1) }}-{{ .scheduler }}-{{ .backend }}-{{ .avail }}
+    {{- end }}
+  {{- end }}
+  - task: test-{{ .scheduler }}
+    {{- if has .workertags .backend }}
+    tags: [{{ index .workertags .backend }}]
+    {{- end }}
+    timeout: 1h30m
+    input_mapping:
+      pool.kube-hosts: {{ .backend }}-pool.kube-hosts
+    config:
+      platform: linux
+      image_resource:
+        type: registry-image
+        source:
+          repository: splatform/catapult
+      inputs:
+      - name: catapult
+      - name: pool.kube-hosts
+      params:
+        QUIET_OUTPUT: true
+        DOWNLOAD_CATAPULT_DEPS: false
+        ENABLE_EIRINI: {{ eq .scheduler "eirini" }}
+{{- if eq .avail "ha" }}
+        HA: true
+{{- end }}
+{{- if eq .avail "all" }}
+{{- print .allbells }}
+{{- end }}
+        KUBECF_TEST_SUITE: smokes
+      run:
+        path: "/bin/bash"
+        args:
+          - -c
+          - |
+            {{ tmpl.Exec "scripts_obtain_kubeconfig" | indent 12 | trimSpace }}
+            {{ tmpl.Exec ( print "scripts_import_" .backend ) | indent 12 | trimSpace }}
+            {{ tmpl.Exec "scripts_test" | indent 12 | trimSpace }}
+  {{- if index .jobs "deploy-k8s" }}
+  {{ tmpl.Exec "common_destroy_k8s" . | indent 2 | trimSpace }}
+  {{- end }}
+{{ end }}

--- a/cap-ci/jobs/pre-upgrade-smoke-tests.tmpl
+++ b/cap-ci/jobs/pre-upgrade-smoke-tests.tmpl
@@ -1,0 +1,58 @@
+{{ define "jobs_pre-upgrade-smoke-tests" }}
+- name: pre-upgrade-smoke-tests-{{ .scheduler }}-{{ .backend }}-{{ .avail }}
+  serial_groups: [{{ .scheduler }}-{{ .backend }}-{{ .avail }}]
+  public: false
+  plan:
+  - get: catapult
+  - get: {{ .backend }}-pool.kube-hosts
+    {{- if ne .position 0 }}
+    passed:
+    - {{ index .jobs_enabled (sub .position 1) }}-{{ .scheduler }}-{{ .backend }}-{{ .avail }}
+    {{- end }}
+    trigger: true
+  {{- if index .jobs "deploy-k8s" }}
+  - get: tfstate-pool
+    {{- if ne .position 0 }}
+    passed:
+    - {{ index .jobs_enabled (sub .position 1) }}-{{ .scheduler }}-{{ .backend }}-{{ .avail }}
+    {{- end }}
+  {{- end }}
+  - task: test-{{ .scheduler }}
+    {{- if has .workertags .backend }}
+    tags: [{{ index .workertags .backend }}]
+    {{- end }}
+    timeout: 1h30m
+    input_mapping:
+      pool.kube-hosts: {{ .backend }}-pool.kube-hosts
+    config:
+      platform: linux
+      image_resource:
+        type: registry-image
+        source:
+          repository: splatform/catapult
+      inputs:
+      - name: catapult
+      - name: pool.kube-hosts
+      params:
+        QUIET_OUTPUT: true
+        DOWNLOAD_CATAPULT_DEPS: false
+        ENABLE_EIRINI: {{ eq .scheduler "eirini" }}
+{{- if eq .avail "ha" }}
+        HA: true
+{{- end }}
+{{- if eq .avail "all" }}
+{{- print .allbells }}
+{{- end }}
+        KUBECF_TEST_SUITE: smokes
+      run:
+        path: "/bin/bash"
+        args:
+          - -c
+          - |
+            {{ tmpl.Exec "scripts_obtain_kubeconfig" | indent 12 | trimSpace }}
+            {{ tmpl.Exec ( print "scripts_import_" .backend ) | indent 12 | trimSpace }}
+            {{ tmpl.Exec "scripts_test" | indent 12 | trimSpace }}
+  {{- if index .jobs "deploy-k8s" }}
+  {{ tmpl.Exec "common_destroy_k8s" . | indent 2 | trimSpace }}
+  {{- end }}
+{{ end }}


### PR DESCRIPTION
Test pipeline deployed at: https://concourse.suse.dev/teams/main/pipelines/bisingh-cap-release

Test pipeline config:

```
workertags:
  # caasp4: suse-internal
jobs:
  deploy-k8s: true
  deploy-kubecf: true
  smoke-tests: true
  cf-acceptance-tests-brain: false
  cf-acceptance-tests: false
  sync-integration-tests: false
  pre-upgrade-smoke-tests: true
  upgrade-kubecf: true
  post-upgrade-smoke-tests: true
  deploy-stratos: false
  destroy-kubecf: true
jobs_ordered:
- deploy-k8s
- deploy-kubecf
- smoke-tests
- cf-acceptance-tests-brain
- cf-acceptance-tests
- sync-integration-tests
- pre-upgrade-smoke-tests
- upgrade-kubecf
- post-upgrade-smoke-tests
- deploy-stratos
- destroy-kubecf
backends:
  caasp4: false
  aks: false
  gke: true
  eks: false
availabilities:
  sa: true
  ha: false
  all: false
schedulers:
  diego: true
  eirini: false
catapult:
  uri: https://github.com/SUSE/catapult
  branch: master
brain:
  verbose: false
  inorder: false
  include: ""
  exclude: ""
cats:
  nodes: 3
  flake-attempts: 5
  timeout-scale: "3.0"
s3:
  bucket: cap-release-artifacts
  regexp: CAP-(.*).tgz
  region: us-east-1
schedule:
  enabled: false
```