### PR TITLE
cap upgrade ci

### DIFF
--- a/cap-ci/cap-pre-release-upgrades.yaml
+++ b/cap-ci/cap-pre-release-upgrades.yaml
@@ -1,0 +1,61 @@
+workertags:
+  # caasp4: suse-internal
+
+jobs:
+  deploy-k8s: true
+  pre-upgrade-deploy-kubecf: true
+  pre-upgrade-smoke-tests: true
+  deploy-stratos: true
+  upgrade-kubecf: true
+  post-upgrade-smoke-tests: true
+  cf-acceptance-tests-brain: true
+  sync-integration-tests: true
+  cf-acceptance-tests: true
+  destroy-kubecf: true
+jobs_ordered:
+- deploy-k8s
+- pre-upgrade-deploy-kubecf
+- pre-upgrade-smoke-tests
+- deploy-stratos
+- upgrade-kubecf
+- post-upgrade-smoke-tests
+- cf-acceptance-tests-brain
+- sync-integration-tests
+- cf-acceptance-tests
+- destroy-kubecf
+backends:
+  caasp4: true
+  aks: true
+  gke: true
+  eks: true
+availabilities:
+  sa: true
+  ha: true
+  all: true
+schedulers:
+  diego: true
+  eirini: true
+catapult:
+  uri: https://github.com/SUSE/catapult
+  branch: master
+brain:
+  verbose: false
+  inorder: false
+  include: ""
+  exclude: ""
+cats:
+  nodes: 3
+  flake-attempts: 5
+  timeout-scale: "3.0"
+s3:
+  bucket: kubecf
+  region: us-west-2
+  regexp: kubecf-bundle-v(.*).tgz
+# Scheduling is required for nightly builds, enabling it removes regular trigger on kubecf bundle.
+schedule:
+  enabled: true
+  start: 12:00 AM
+  stop: 12:10 AM
+  location: America/Vancouver
+logs:
+  enabled: true

--- a/cap-ci/cap-release-upgrades.yaml
+++ b/cap-ci/cap-release-upgrades.yaml
@@ -1,0 +1,57 @@
+workertags:
+  # caasp4: suse-internal
+
+jobs:
+  deploy-k8s: true
+  pre-upgrade-deploy-kubecf: true
+  pre-upgrade-smoke-tests: true
+  deploy-stratos: true
+  upgrade-kubecf: true
+  post-upgrade-smoke-tests: true
+  cf-acceptance-tests-brain: true
+  cf-acceptance-tests: true
+  sync-integration-tests: true
+  destroy-kubecf: true
+jobs_ordered:
+- deploy-k8s
+- pre-upgrade-deploy-kubecf
+- pre-upgrade-smoke-tests
+- deploy-stratos
+- upgrade-kubecf
+- post-upgrade-smoke-tests
+- cf-acceptance-tests-brain
+- cf-acceptance-tests
+- sync-integration-tests
+- destroy-kubecf
+backends:
+  caasp4: true
+  aks: true
+  gke: true
+  eks: true
+availabilities:
+  sa: true
+  ha: true
+  all: true
+schedulers:
+  diego: true
+  eirini: true
+catapult:
+  uri: https://github.com/SUSE/catapult
+  branch: master
+brain:
+  verbose: false
+  inorder: false
+  include: ""
+  exclude: ""
+cats:
+  nodes: 3
+  flake-attempts: 5
+  timeout-scale: "3.0"
+s3:
+  bucket: cap-release-artifacts
+  regexp: CAP-(.*).tgz
+  region: us-east-1
+schedule:
+  enabled: false
+logs:
+  enabled: true

--- a/cap-ci/jobs/pre-upgrade-deploy-kubecf.tmpl
+++ b/cap-ci/jobs/pre-upgrade-deploy-kubecf.tmpl
@@ -1,0 +1,83 @@
+{{ define "jobs_pre-upgrade-deploy-kubecf" }}
+- name: pre-upgrade-deploy-kubecf-{{ .scheduler }}-{{ .backend }}-{{ .avail }}
+  public: false
+  plan:
+  {{- if not (index .jobs "deploy-k8s") }}
+  - get: s3.kubecf-bundle
+    trigger: true
+  {{- end }}
+  - get: helm-chart.kubecf-chart
+  - get: helm-chart.cfo-chart
+  {{- if index .jobs "deploy-stratos" }}
+  - get: helm-chart.stratos-chart
+    {{- if not (index .jobs "deploy-k8s") }}
+    trigger: true
+    {{- end }}
+  - get: helm-chart.stratos-metrics-chart
+    {{- if not (index .jobs "deploy-k8s") }}
+    trigger: true
+    {{- end }}
+  {{ end }}
+  - get: catapult
+  {{- if index .jobs "deploy-k8s" }}
+  - get: {{ .backend }}-pool.kube-hosts
+    passed:
+    - deploy-k8s-{{ .scheduler }}-{{ .backend }}-{{ .avail }}
+    trigger: true
+  - get: tfstate-pool
+    passed:
+    - deploy-k8s-{{ .scheduler }}-{{ .backend }}-{{ .avail }}
+  {{- else }}
+  - put: {{ .backend }}-pool.kube-hosts
+    params:
+      acquire: true
+      depth: 1
+    timeout: 6m
+  {{- end }}
+  - task: deploy-kubecf
+    {{- if has .workertags .backend }}
+    tags: [{{ index .workertags .backend }}]
+    {{- end }}
+    timeout: 2h30m
+    input_mapping:
+      pool.kube-hosts: {{ .backend }}-pool.kube-hosts
+    config:
+      platform: linux
+      image_resource:
+        type: registry-image
+        source:
+          repository: splatform/catapult
+      inputs:
+      - name: catapult
+      - name: helm-chart.kubecf-chart
+      - name: helm-chart.cfo-chart
+      - name: pool.kube-hosts
+      params:
+        BRAIN_VERBOSE: {{ .brain.verbose }}
+        BRAIN_INORDER: {{ .brain.inorder }}
+        BRAIN_INCLUDE: "{{ .brain.include }}"
+        BRAIN_EXCLUDE: "{{ .brain.exclude }}"
+        CATS_NODES: {{ .cats.nodes }}
+        CATS_FLAKE_ATTEMPTS: {{ index .cats "flake-attempts" }}
+        CATS_TIMEOUT_SCALE: {{ index .cats "timeout-scale" }}
+        QUIET_OUTPUT: true
+        DOWNLOAD_CATAPULT_DEPS: false
+        ENABLE_EIRINI: {{ eq .scheduler "eirini" }}
+{{- if eq .avail "ha" }}
+        HA: true
+{{- end }}
+{{- if eq .avail "all" }}
+{{- print .allbells }}
+{{- end }}
+      run:
+        path: "/bin/bash"
+        args:
+          - -c
+          - |
+            {{ tmpl.Exec "scripts_obtain_kubeconfig" | indent 12 | trimSpace }}
+            {{ tmpl.Exec ( print "scripts_import_" .backend ) | indent 12 | trimSpace }}
+            {{ tmpl.Exec "scripts_pre_upgrade_deploy_kubecf" | indent 12 | trimSpace }}
+  {{- if index .jobs "deploy-k8s" }}
+  {{ tmpl.Exec "common_destroy_k8s" . | indent 2 | trimSpace }}
+  {{- end }}
+{{ end }}

--- a/cap-ci/pipeline.yaml.tmpl
+++ b/cap-ci/pipeline.yaml.tmpl
@@ -80,6 +80,24 @@ resources:
     endpoint: null
 {{ end }}
 
+{{- if index $config.jobs "pre-upgrade-deploy-kubecf" }}
+- name: helm-chart.kubecf-chart
+  type: helm-chart
+  source:
+    chart: suse/kubecf
+    repos:
+    - name: suse
+      url: https://kubernetes-charts.suse.com/
+
+- name: helm-chart.cfo-chart
+  type: helm-chart
+  source:
+    chart: suse/cf-operator
+    repos:
+    - name: suse
+      url: https://kubernetes-charts.suse.com/
+{{ end }}
+
 {{- if eq $config.schedule.enabled true }}
 - name: schedule-interval
   type: time

--- a/cap-ci/scripts/pre_upgrade_deploy_kubecf.tmpl
+++ b/cap-ci/scripts/pre_upgrade_deploy_kubecf.tmpl
@@ -1,0 +1,9 @@
+{{ define "scripts_pre_upgrade_deploy_kubecf" }}
+{{- /* Attention: PWD = ___/catapult here */}}
+{{- /* deploy kubecf from chart */}}
+export SCF_CHART="$(readlink -f ../helm-chart.kubecf-chart/*.tgz)"
+export OPERATOR_CHART_URL="$(readlink -f ../helm-chart.cfo-chart/*.tgz)"
+export DOCKER_ORG=cap-staging
+export QUIET_OUTPUT=true
+make kubecf && make kubecf-login # ensure cf is there
+{{ end }}


### PR DESCRIPTION
implements cap-pre-release-upgrades.yaml and cap-release-upgrades.yaml. 

1. Triggers CI when there is a new RC in s3 bucket (or scheduled deployment for nightly)
2. Deploys pre-upgrade kubecf from last release i.e helm charts
3. sanity of pre-upgrade deployment i.e pre-upgrade smokes
4. installs latest available stratos
5. Upgrades to latest available RC or nightly from s3 bucket
6. Sanity post upgrades i.e. smokes, brains, sits and cats

Test: https://concourse.suse.dev/teams/main/pipelines/prabal-Upgrades-GKE-CAP-RC-sa-diego