### PR TITLE
fix issues with create pipeline

### DIFF
--- a/cap-ci/cap-pre-release.yaml
+++ b/cap-ci/cap-pre-release.yaml
@@ -55,3 +55,5 @@ schedule:
   start: 12:00 AM
   stop: 12:10 AM
   location: America/Vancouver
+logs:
+  enabled: true

--- a/cap-ci/cap-release.yaml
+++ b/cap-ci/cap-release.yaml
@@ -2,7 +2,7 @@ workertags:
   # caasp4: suse-internal
 
 jobs:
-  deploy-k8s: false
+  deploy-k8s: true
   deploy-kubecf: true
   smoke-tests: true
   cf-acceptance-tests-brain: true

--- a/cap-ci/jobs/pre-upgrade-deploy-kubecf.tmpl
+++ b/cap-ci/jobs/pre-upgrade-deploy-kubecf.tmpl
@@ -24,9 +24,6 @@
     passed:
     - deploy-k8s-{{ .scheduler }}-{{ .backend }}-{{ .avail }}
     trigger: true
-  - get: tfstate-pool
-    passed:
-    - deploy-k8s-{{ .scheduler }}-{{ .backend }}-{{ .avail }}
   {{- else }}
   - put: {{ .backend }}-pool.kube-hosts
     params:


### PR DESCRIPTION
fixes:

- `resource 's3.klog-destination' is not used` for cap-release
- `<$config.logs.enabled>: map has no entry for key "logs"` for cap-pre-release

and removes tfstate-pool from upgrade CIs