### PR TITLE
remove trigger for stratos and metrics

### DIFF
--- a/cap-ci/cap-pre-release.yaml
+++ b/cap-ci/cap-pre-release.yaml
@@ -55,3 +55,5 @@ schedule:
   start: 12:00 AM
   stop: 12:10 AM
   location: America/Vancouver
+logs:
+  enabled: true

--- a/cap-ci/cap-release.yaml
+++ b/cap-ci/cap-release.yaml
@@ -2,7 +2,7 @@ workertags:
   # caasp4: suse-internal
 
 jobs:
-  deploy-k8s: false
+  deploy-k8s: true
   deploy-kubecf: true
   smoke-tests: true
   cf-acceptance-tests-brain: true

--- a/cap-ci/jobs/deploy-k8s.tmpl
+++ b/cap-ci/jobs/deploy-k8s.tmpl
@@ -12,9 +12,9 @@
   {{ end }}
   {{- if index .jobs "deploy-stratos" }}
   - get: helm-chart.stratos-chart
-    trigger: true
+    trigger: false
   - get: helm-chart.stratos-metrics-chart
-    trigger: true
+    trigger: false
   {{ end }}
   - get: catapult
   - task: deploy-k8s

--- a/cap-ci/jobs/deploy-kubecf.tmpl
+++ b/cap-ci/jobs/deploy-kubecf.tmpl
@@ -9,11 +9,11 @@
   {{- if index .jobs "deploy-stratos" }}
   - get: helm-chart.stratos-chart
     {{- if not (index .jobs "deploy-k8s") }}
-    trigger: true
+    trigger: false
     {{- end }}
   - get: helm-chart.stratos-metrics-chart
     {{- if not (index .jobs "deploy-k8s") }}
-    trigger: true
+    trigger: false
     {{- end }}
   {{ end }}
   - get: catapult

--- a/cap-ci/jobs/pre-upgrade-deploy-kubecf.tmpl
+++ b/cap-ci/jobs/pre-upgrade-deploy-kubecf.tmpl
@@ -24,9 +24,6 @@
     passed:
     - deploy-k8s-{{ .scheduler }}-{{ .backend }}-{{ .avail }}
     trigger: true
-  - get: tfstate-pool
-    passed:
-    - deploy-k8s-{{ .scheduler }}-{{ .backend }}-{{ .avail }}
   {{- else }}
   - put: {{ .backend }}-pool.kube-hosts
     params:


### PR DESCRIPTION
This PR is based on top of https://github.com/SUSE/cap/pull/47. 

I have left the mechanism to use stratos and metrics builds as triggers in place, in case we need it in future or if its required when we create stratos' own pipelines