### PR TITLE
fix: Always create resource s3.kubecf-bundle

### DIFF
--- a/cap-ci/pipeline.yaml.tmpl
+++ b/cap-ci/pipeline.yaml.tmpl
@@ -59,7 +59,6 @@ resources:
     branch: {{ $config.catapult.branch }}
     uri: {{ $config.catapult.uri }}
 
-{{- if index $config.jobs "deploy-k8s" }}
 - name: s3.kubecf-bundle
   type: s3
   source:
@@ -68,7 +67,6 @@ resources:
     secret_access_key: ((aws-secret-key))
     regexp: {{ $config.s3.regexp }}
     region_name: {{ $config.s3.region }}
-{{- end }}
 
 {{- if index $config.jobs "minibroker-integration-tests" }}
 - name: s3.minibroker


### PR DESCRIPTION
It was only created when deploy-k8s=true. If one of course doesn't create the
cluster on the pipeline, flying it will complain of the missing resource.

Note: I haven't tested this besides with:
```
jobs:
  deploy-k8s: false
  deploy-kubecf: true
  smoke-tests: true
  cf-acceptance-tests-brain: false
  sync-integration-tests: false
  minibroker-integration-tests: false
  cf-acceptance-tests: false
  upgrade-kubecf: false
  deploy-stratos: false
  destroy-kubecf: true
```

As I see no humane way of doing that.