### PR TITLE
don't use default variables from catapult to set cf admin password

### DIFF
--- a/cap-ci/scripts/test_mits.tmpl
+++ b/cap-ci/scripts/test_mits.tmpl
@@ -9,7 +9,7 @@ source build$CLUSTER_NAME/.envrc
 domain=$(kubectl get configmap -n kube-system cap-values -o json | jq -r '.data["domain"]')
 admin_pass=$(kubectl get secret --namespace scf \
                      var-cf-admin-password \
-                     -o jsonpath='{.data.password}' | base64 --decode)
+                     --output 'jsonpath={.data.password}' | base64 --decode)
 
 export CF_ADMIN_PASSWORD=${admin_pass}
 export MINIBROKER_CHART_TARBALL="$(readlink -f ../s3.minibroker/*.tgz)"

--- a/cap-ci/scripts/test_mits.tmpl
+++ b/cap-ci/scripts/test_mits.tmpl
@@ -5,11 +5,13 @@
 set -o errexit -o nounset -o pipefail
 
 export CLUSTER_NAME=$(cat ../pool.kube-hosts/name)
-source include/defaults_global_private.sh
 source build$CLUSTER_NAME/.envrc
 domain=$(kubectl get configmap -n kube-system cap-values -o json | jq -r '.data["domain"]')
+admin_pass=$(kubectl get secret --namespace scf \
+                     var-cf-admin-password \
+                     -o jsonpath='{.data.password}' | base64 --decode)
 
-export CF_ADMIN_PASSWORD=${CLUSTER_PASSWORD}
+export CF_ADMIN_PASSWORD=${admin_pass}
 export MINIBROKER_CHART_TARBALL="$(readlink -f ../s3.minibroker/*.tgz)"
 export MITS_CHART_TARBALL="$(readlink -f ../mits-gh-release/*.tgz)"
 export CF_API_ENDPOINT="https://api.${domain}"


### PR DESCRIPTION
catapult has stopped using `include/defaults_global_private.sh` to cf admin password https://github.com/SUSE/catapult/commit/33da3e99437304c6b2e3cb0121d3b11d243cae4a.
This PR accommodates these catapult changes.

Test: https://concourse.suse.dev/teams/main/pipelines/prabal-AKS-smoke/jobs/minibroker-integration-tests-diego-gke-sa/builds/28