### PR TITLE
update default ci configs

### DIFF
--- a/cap-ci/cap-pre-release-upgrades.yaml
+++ b/cap-ci/cap-pre-release-upgrades.yaml
@@ -5,7 +5,7 @@ jobs:
   deploy-k8s: true
   pre-upgrade-deploy-kubecf: true
   pre-upgrade-smoke-tests: true
-  deploy-stratos: true
+  deploy-stratos: false
   upgrade-kubecf: true
   post-upgrade-smoke-tests: true
   cf-acceptance-tests-brain: true
@@ -31,8 +31,8 @@ backends:
   gke: true
   eks: true
 availabilities:
-  sa: true
-  ha: true
+  sa: false
+  ha: false
   all: true
 schedulers:
   diego: true

--- a/cap-ci/cap-pre-release.yaml
+++ b/cap-ci/cap-pre-release.yaml
@@ -10,7 +10,7 @@ jobs:
   minibroker-integration-tests: true
   cf-acceptance-tests: true
   upgrade-kubecf: true
-  deploy-stratos: true
+  deploy-stratos: false
   destroy-kubecf: true
 jobs_ordered:
 - deploy-k8s
@@ -29,8 +29,8 @@ backends:
   gke: true
   eks: true
 availabilities:
-  sa: true
-  ha: true
+  sa: false
+  ha: false
   all: true
 schedulers:
   diego: true

--- a/cap-ci/cap-release-upgrades.yaml
+++ b/cap-ci/cap-release-upgrades.yaml
@@ -5,7 +5,7 @@ jobs:
   deploy-k8s: true
   pre-upgrade-deploy-kubecf: true
   pre-upgrade-smoke-tests: true
-  deploy-stratos: true
+  deploy-stratos: false
   upgrade-kubecf: true
   post-upgrade-smoke-tests: true
   cf-acceptance-tests-brain: true
@@ -31,8 +31,8 @@ backends:
   gke: true
   eks: true
 availabilities:
-  sa: true
-  ha: true
+  sa: false
+  ha: false
   all: true
 schedulers:
   diego: true

--- a/cap-ci/cap-release.yaml
+++ b/cap-ci/cap-release.yaml
@@ -10,7 +10,7 @@ jobs:
   minibroker-integration-tests: true
   cf-acceptance-tests: true
   upgrade-kubecf: true
-  deploy-stratos: true
+  deploy-stratos: false
   destroy-kubecf: true
 jobs_ordered:
 - deploy-k8s
@@ -29,8 +29,8 @@ backends:
   gke: true
   eks: true
 availabilities:
-  sa: true
-  ha: true
+  sa: false
+  ha: false
   all: true
 schedulers:
   diego: true


### PR DESCRIPTION
update configs to match what is actually deployed on concourse 
We are no longer enabling HA, SA and stratos in cap pre release and cap release CIs. Thus, our default configs must reflect our current pipeline definition.
 