### PR TITLE
Tag all pipelines with suse-internal

### DIFF
--- a/cap-ci/cap-pre-release-upgrades.yaml
+++ b/cap-ci/cap-pre-release-upgrades.yaml
@@ -1,5 +1,5 @@
 workertags:
-  # caasp4: suse-internal
+  caasp4: suse-internal
 
 jobs:
   deploy-k8s: true

--- a/cap-ci/cap-pre-release.yaml
+++ b/cap-ci/cap-pre-release.yaml
@@ -1,5 +1,5 @@
 workertags:
-  # caasp4: suse-internal
+  caasp4: suse-internal
 
 jobs:
   deploy-k8s: true

--- a/cap-ci/cap-release-upgrades.yaml
+++ b/cap-ci/cap-release-upgrades.yaml
@@ -1,5 +1,5 @@
 workertags:
-  # caasp4: suse-internal
+  caasp4: suse-internal
 
 jobs:
   deploy-k8s: true

--- a/cap-ci/cap-release.yaml
+++ b/cap-ci/cap-release.yaml
@@ -1,5 +1,5 @@
 workertags:
-  # caasp4: suse-internal
+  caasp4: suse-internal
 
 jobs:
   deploy-k8s: true


### PR DESCRIPTION
This makes them run on the Concourse worker on ECP.

I will wait for this to be merged to fly them.