### PR TITLE
Provide no-op on deploy-k8s job when caasp4, for now

### DIFF
--- a/cap-ci/scripts/deploy_k8s.tmpl
+++ b/cap-ci/scripts/deploy_k8s.tmpl
@@ -28,6 +28,8 @@ elif [[ ${BACKEND} == "eks" ]]; then
   (cd catapult; BACKEND=eks EKS_KEYPAIR=${KEYPAIR} EKS_DEPLOYER_ROLE_ARN='((aws-service-account-ci-creds.deployer-role-arn))' EKS_CLUSTER_ROLE_NAME='((aws-service-account-ci-creds.cluster-role-name))' EKS_CLUSTER_ROLE_ARN='((aws-service-account-ci-creds.cluster-role-arn))' EKS_WORKER_NODE_ROLE_NAME='((aws-service-account-ci-creds.worker-node-role-name))' EKS_WORKER_NODE_ROLE_ARN='((aws-service-account-ci-creds.worker-node-role-arn))' KUBE_AUTHORIZED_ROLE_ARN='((aws-service-account-ci-creds.kube-authorized-role-arn))' EKS_CLUSTER_NAME=${CLUSTER_NAME} CLUSTER_NAME=${CLUSTER_NAME} TF_KEY=${TF_KEY} make k8s)
   echo ${CLUSTER_NAME} > kubeconfig-pool/name
   cp catapult/build${CLUSTER_NAME}/kubeconfig kubeconfig-pool/metadata
+elif [[ ${BACKEND} == "caasp4os" ]]; then
+  echo "CaaSP clusters are already created. Doing nothing."
 else
   echo "CI cannot create ${BACKEND} cluster"
   exit 1


### PR DESCRIPTION
CaaSP4 clusters are currently pets: we create them out of the pipeline, be it in
ECP (we need to build a skuba image, and configure dind for concourse) or be it
KVM (not added to catapult yet).

Hence, for caasp4 clusters, we need to not run deploy-k8s job.

Sadly, the pipeline definitions don't have a simple way to disable one job for 1
backend only.

We could deploy additional
  {cap-pre-release,cap-release,cap-release-upgrades,…}-caasp4.yaml
pipelines, but it's messy. Or we could change the gomplate templating, for which we
don't have time now.

Hence, make deploy-k8s do nothing when caasp4, for now.