### PR TITLE
Add {cap*release*}-caasp.yaml pipelines for now

### DIFF
--- a/cap-ci/cap-pre-release-caasp.yaml
+++ b/cap-ci/cap-pre-release-caasp.yaml
@@ -1,8 +1,8 @@
 workertags:
-  # caasp4: suse-internal
+  caasp4: suse-internal
 
 jobs:
-  deploy-k8s: true
+  deploy-k8s: false
   deploy-kubecf: true
   smoke-tests: true
   cf-acceptance-tests-brain: true
@@ -24,10 +24,10 @@ jobs_ordered:
 - deploy-stratos
 - destroy-kubecf
 backends:
-  caasp4: false
-  aks: true
-  gke: true
-  eks: true
+  caasp4: true
+  aks: false
+  gke: false
+  eks: false
 availabilities:
   sa: false
   ha: false

--- a/cap-ci/cap-pre-release-upgrades-caasp.yaml
+++ b/cap-ci/cap-pre-release-upgrades-caasp.yaml
@@ -1,33 +1,35 @@
 workertags:
-  # caasp4: suse-internal
+  caasp4: suse-internal
 
 jobs:
-  deploy-k8s: true
-  deploy-kubecf: true
-  smoke-tests: true
+  deploy-k8s: false
+  pre-upgrade-deploy-kubecf: true
+  pre-upgrade-smoke-tests: true
+  deploy-stratos: false
+  upgrade-kubecf: true
+  post-upgrade-smoke-tests: true
   cf-acceptance-tests-brain: true
   sync-integration-tests: true
   minibroker-integration-tests: true
   cf-acceptance-tests: true
-  upgrade-kubecf: true
-  deploy-stratos: false
   destroy-kubecf: true
 jobs_ordered:
 - deploy-k8s
-- deploy-kubecf
-- smoke-tests
+- pre-upgrade-deploy-kubecf
+- pre-upgrade-smoke-tests
+- deploy-stratos
+- upgrade-kubecf
+- post-upgrade-smoke-tests
 - cf-acceptance-tests-brain
 - sync-integration-tests
 - minibroker-integration-tests
 - cf-acceptance-tests
-- upgrade-kubecf
-- deploy-stratos
 - destroy-kubecf
 backends:
-  caasp4: false
-  aks: true
-  gke: true
-  eks: true
+  caasp4: true
+  aks: false
+  gke: false
+  eks: false
 availabilities:
   sa: false
   ha: false

--- a/cap-ci/cap-pre-release-upgrades.yaml
+++ b/cap-ci/cap-pre-release-upgrades.yaml
@@ -26,7 +26,7 @@ jobs_ordered:
 - cf-acceptance-tests
 - destroy-kubecf
 backends:
-  caasp4: true
+  caasp4: false
   aks: true
   gke: true
   eks: true

--- a/cap-ci/cap-release-caasp.yaml
+++ b/cap-ci/cap-release-caasp.yaml
@@ -1,8 +1,8 @@
 workertags:
-  # caasp4: suse-internal
+  caasp4: suse-internal
 
 jobs:
-  deploy-k8s: true
+  deploy-k8s: false
   deploy-kubecf: true
   smoke-tests: true
   cf-acceptance-tests-brain: true
@@ -52,14 +52,10 @@ s3minibroker:
   region: us-east-1
   regexp: minibroker-charts/minibroker-(.*).tgz
 s3:
-  bucket: kubecf
-  region: us-west-2
-  regexp: kubecf-bundle-v(.*).tgz
-# Scheduling is required for nightly builds, enabling it removes regular trigger on kubecf bundle.
+  bucket: cap-release-artifacts
+  regexp: CAP-(.*).tgz
+  region: us-east-1
 schedule:
-  enabled: true
-  start: 12:00 AM
-  stop: 12:10 AM
-  location: America/Vancouver
+  enabled: false
 logs:
   enabled: true

--- a/cap-ci/cap-release-caasp.yaml
+++ b/cap-ci/cap-release-caasp.yaml
@@ -24,10 +24,10 @@ jobs_ordered:
 - deploy-stratos
 - destroy-kubecf
 backends:
-  caasp4: false
-  aks: true
-  gke: true
-  eks: true
+  caasp4: true
+  aks: false
+  gke: false
+  eks: false
 availabilities:
   sa: false
   ha: false

--- a/cap-ci/cap-release-upgrades-caasp.yaml
+++ b/cap-ci/cap-release-upgrades-caasp.yaml
@@ -1,27 +1,29 @@
 workertags:
-  # caasp4: suse-internal
+  caasp4: suse-internal
 
 jobs:
   deploy-k8s: true
-  deploy-kubecf: true
-  smoke-tests: true
+  pre-upgrade-deploy-kubecf: true
+  pre-upgrade-smoke-tests: true
+  deploy-stratos: false
+  upgrade-kubecf: true
+  post-upgrade-smoke-tests: true
   cf-acceptance-tests-brain: true
   sync-integration-tests: true
   minibroker-integration-tests: true
   cf-acceptance-tests: true
-  upgrade-kubecf: true
-  deploy-stratos: false
   destroy-kubecf: true
 jobs_ordered:
 - deploy-k8s
-- deploy-kubecf
-- smoke-tests
+- pre-upgrade-deploy-kubecf
+- pre-upgrade-smoke-tests
+- deploy-stratos
+- upgrade-kubecf
+- post-upgrade-smoke-tests
 - cf-acceptance-tests-brain
 - sync-integration-tests
 - minibroker-integration-tests
 - cf-acceptance-tests
-- upgrade-kubecf
-- deploy-stratos
 - destroy-kubecf
 backends:
   caasp4: false
@@ -52,14 +54,10 @@ s3minibroker:
   region: us-east-1
   regexp: minibroker-charts/minibroker-(.*).tgz
 s3:
-  bucket: kubecf
-  region: us-west-2
-  regexp: kubecf-bundle-v(.*).tgz
-# Scheduling is required for nightly builds, enabling it removes regular trigger on kubecf bundle.
+  bucket: cap-release-artifacts
+  regexp: CAP-(.*).tgz
+  region: us-east-1
 schedule:
-  enabled: true
-  start: 12:00 AM
-  stop: 12:10 AM
-  location: America/Vancouver
+  enabled: false
 logs:
   enabled: true

--- a/cap-ci/cap-release-upgrades-caasp.yaml
+++ b/cap-ci/cap-release-upgrades-caasp.yaml
@@ -2,7 +2,7 @@ workertags:
   caasp4: suse-internal
 
 jobs:
-  deploy-k8s: true
+  deploy-k8s: false
   pre-upgrade-deploy-kubecf: true
   pre-upgrade-smoke-tests: true
   deploy-stratos: false
@@ -26,10 +26,10 @@ jobs_ordered:
 - cf-acceptance-tests
 - destroy-kubecf
 backends:
-  caasp4: false
-  aks: true
-  gke: true
-  eks: true
+  caasp4: true
+  aks: false
+  gke: false
+  eks: false
 availabilities:
   sa: false
   ha: false

--- a/cap-ci/cap-release-upgrades.yaml
+++ b/cap-ci/cap-release-upgrades.yaml
@@ -26,7 +26,7 @@ jobs_ordered:
 - cf-acceptance-tests
 - destroy-kubecf
 backends:
-  caasp4: true
+  caasp4: false
   aks: true
   gke: true
   eks: true

--- a/cap-ci/cap-release.yaml
+++ b/cap-ci/cap-release.yaml
@@ -24,7 +24,7 @@ jobs_ordered:
 - deploy-stratos
 - destroy-kubecf
 backends:
-  caasp4: true
+  caasp4: false
   aks: true
   gke: true
   eks: true


### PR DESCRIPTION
Add copies of all pipelines, for caasp.

These pipelines have the deploy-k8s job disabled, as the clusters are pets.

We are in a pickle:
- We cannot deploy cap pipelines where 1 provider has 1 job
  less because of the structure of the template.
- we cannot add a no-op on deploy-k8s when caasp because of the `put` step on
  it (see https://github.com/SUSE/cap/pull/60).

We could redo the templating right now (no), or we can just create copies of the
pipelines, configured with only caasp4 and without the deploy-k8s job. Which is
what this commit does.