### PR TITLE
Disable collecting klogs on caasp pipelines for now

### DIFF
--- a/cap-ci/cap-pre-release-caasp.yaml
+++ b/cap-ci/cap-pre-release-caasp.yaml
@@ -62,4 +62,4 @@ schedule:
   stop: 12:10 AM
   location: America/Vancouver
 logs:
-  enabled: true
+  enabled: false

--- a/cap-ci/cap-pre-release-upgrades-caasp.yaml
+++ b/cap-ci/cap-pre-release-upgrades-caasp.yaml
@@ -64,4 +64,4 @@ schedule:
   stop: 12:10 AM
   location: America/Vancouver
 logs:
-  enabled: true
+  enabled: false

--- a/cap-ci/cap-release-caasp.yaml
+++ b/cap-ci/cap-release-caasp.yaml
@@ -58,4 +58,4 @@ s3:
 schedule:
   enabled: false
 logs:
-  enabled: true
+  enabled: false

--- a/cap-ci/cap-release-upgrades-caasp.yaml
+++ b/cap-ci/cap-release-upgrades-caasp.yaml
@@ -60,4 +60,4 @@ s3:
 schedule:
   enabled: false
 logs:
-  enabled: true
+  enabled: false


### PR DESCRIPTION
If not, we hit https://github.com/SUSE/cap/issues/51.