### PR TITLE
Enable sa, ha in cap-pre-release-caasp pipeline

### DIFF
--- a/cap-ci/cap-pre-release-caasp.yaml
+++ b/cap-ci/cap-pre-release-caasp.yaml
@@ -29,8 +29,8 @@ backends:
   gke: false
   eks: false
 availabilities:
-  sa: false
-  ha: false
+  sa: true
+  ha: true
   all: true
 schedulers:
   diego: true


### PR DESCRIPTION
Flown already with `./create_pipeline.sh concourse.suse.dev cap-pre-release-caasp`.