### PR TITLE
DO NOT MERGE YET Add new `continue_on_failure` option to all pipelines

### DIFF
--- a/cap-ci/cap-pre-release-caasp.yaml
+++ b/cap-ci/cap-pre-release-caasp.yaml
@@ -23,6 +23,7 @@ jobs_ordered:
 - upgrade-kubecf
 - deploy-stratos
 - destroy-kubecf
+continue_on_failure: false # continues on job failure, if not deploy or smokes
 backends:
   caasp4: true
   aks: false

--- a/cap-ci/cap-pre-release-caasp.yaml
+++ b/cap-ci/cap-pre-release-caasp.yaml
@@ -23,7 +23,7 @@ jobs_ordered:
 - upgrade-kubecf
 - deploy-stratos
 - destroy-kubecf
-continue_on_failure: false # continues on job failure, if not deploy or smokes
+continue_on_failure: true # continues on job failure, if not deploy or smokes
 backends:
   caasp4: true
   aks: false

--- a/cap-ci/cap-pre-release-caasp.yaml
+++ b/cap-ci/cap-pre-release-caasp.yaml
@@ -11,7 +11,7 @@ jobs:
   cf-acceptance-tests: true
   upgrade-kubecf: true
   deploy-stratos: false
-  destroy-kubecf: true
+  destroy-kubecf: false
 jobs_ordered:
 - deploy-k8s
 - deploy-kubecf

--- a/cap-ci/cap-pre-release-upgrades-caasp.yaml
+++ b/cap-ci/cap-pre-release-upgrades-caasp.yaml
@@ -12,7 +12,7 @@ jobs:
   sync-integration-tests: true
   minibroker-integration-tests: true
   cf-acceptance-tests: true
-  destroy-kubecf: true
+  destroy-kubecf: false
 jobs_ordered:
 - deploy-k8s
 - pre-upgrade-deploy-kubecf

--- a/cap-ci/cap-pre-release-upgrades-caasp.yaml
+++ b/cap-ci/cap-pre-release-upgrades-caasp.yaml
@@ -25,6 +25,7 @@ jobs_ordered:
 - minibroker-integration-tests
 - cf-acceptance-tests
 - destroy-kubecf
+continue_on_failure: false # continues on job failure, if not deploy or smokes
 backends:
   caasp4: true
   aks: false

--- a/cap-ci/cap-pre-release-upgrades.yaml
+++ b/cap-ci/cap-pre-release-upgrades.yaml
@@ -25,6 +25,7 @@ jobs_ordered:
 - minibroker-integration-tests
 - cf-acceptance-tests
 - destroy-kubecf
+continue_on_failure: false # continues on job failure, if not deploy or smokes
 backends:
   caasp4: false
   aks: true

--- a/cap-ci/cap-pre-release.yaml
+++ b/cap-ci/cap-pre-release.yaml
@@ -23,6 +23,7 @@ jobs_ordered:
 - upgrade-kubecf
 - deploy-stratos
 - destroy-kubecf
+continue_on_failure: false # continues on job failure, if not deploy or smokes
 backends:
   caasp4: false
   aks: true

--- a/cap-ci/cap-release-caasp.yaml
+++ b/cap-ci/cap-release-caasp.yaml
@@ -23,6 +23,7 @@ jobs_ordered:
 - upgrade-kubecf
 - deploy-stratos
 - destroy-kubecf
+continue_on_failure: false # continues on job failure, if not deploy or smokes
 backends:
   caasp4: true
   aks: false

--- a/cap-ci/cap-release-caasp.yaml
+++ b/cap-ci/cap-release-caasp.yaml
@@ -11,7 +11,7 @@ jobs:
   cf-acceptance-tests: true
   upgrade-kubecf: true
   deploy-stratos: false
-  destroy-kubecf: true
+  destroy-kubecf: false
 jobs_ordered:
 - deploy-k8s
 - deploy-kubecf

--- a/cap-ci/cap-release-upgrades-caasp.yaml
+++ b/cap-ci/cap-release-upgrades-caasp.yaml
@@ -12,7 +12,7 @@ jobs:
   sync-integration-tests: true
   minibroker-integration-tests: true
   cf-acceptance-tests: true
-  destroy-kubecf: true
+  destroy-kubecf: false
 jobs_ordered:
 - deploy-k8s
 - pre-upgrade-deploy-kubecf

--- a/cap-ci/cap-release-upgrades-caasp.yaml
+++ b/cap-ci/cap-release-upgrades-caasp.yaml
@@ -25,6 +25,7 @@ jobs_ordered:
 - minibroker-integration-tests
 - cf-acceptance-tests
 - destroy-kubecf
+continue_on_failure: false # continues on job failure, if not deploy or smokes
 backends:
   caasp4: true
   aks: false

--- a/cap-ci/cap-release-upgrades.yaml
+++ b/cap-ci/cap-release-upgrades.yaml
@@ -25,6 +25,7 @@ jobs_ordered:
 - minibroker-integration-tests
 - cf-acceptance-tests
 - destroy-kubecf
+continue_on_failure: false # continues on job failure, if not deploy or smokes
 backends:
   caasp4: false
   aks: true

--- a/cap-ci/cap-release.yaml
+++ b/cap-ci/cap-release.yaml
@@ -23,6 +23,7 @@ jobs_ordered:
 - upgrade-kubecf
 - deploy-stratos
 - destroy-kubecf
+continue_on_failure: false # continues on job failure, if not deploy or smokes
 backends:
   caasp4: false
   aks: true

--- a/cap-ci/jobs/cf-acceptance-tests-brain.tmpl
+++ b/cap-ci/jobs/cf-acceptance-tests-brain.tmpl
@@ -5,7 +5,7 @@
   plan:
   - get: catapult
   - get: {{ .backend }}-pool.kube-hosts
-    {{- if ne .position 0 }}
+    {{- if and (ne .position 0) (not .continue_on_failure) }}
     passed:
     - {{ index .jobs_enabled (sub .position 1) }}-{{ .scheduler }}-{{ .backend }}-{{ .avail }}
     {{- end }}

--- a/cap-ci/jobs/cf-acceptance-tests.tmpl
+++ b/cap-ci/jobs/cf-acceptance-tests.tmpl
@@ -5,7 +5,7 @@
   plan:
   - get: catapult
   - get: {{ .backend }}-pool.kube-hosts
-    {{- if ne .position 0 }}
+    {{- if and (ne .position 0) (not .continue_on_failure) }}
     passed:
     - {{ index .jobs_enabled (sub .position 1) }}-{{ .scheduler }}-{{ .backend }}-{{ .avail }}
     {{- end }}

--- a/cap-ci/jobs/deploy-stratos.tmpl
+++ b/cap-ci/jobs/deploy-stratos.tmpl
@@ -7,7 +7,7 @@
   - get: helm-chart.stratos-chart
   - get: helm-chart.stratos-metrics-chart
   - get: {{ .backend }}-pool.kube-hosts
-    {{- if ne .position 0 }}
+    {{- if and (ne .position 0) (not .continue_on_failure) }}
     passed:
     - {{ index .jobs_enabled (sub .position 1) }}-{{ .scheduler }}-{{ .backend }}-{{ .avail }}
     {{- end }}

--- a/cap-ci/jobs/minibroker-integration-tests.tmpl
+++ b/cap-ci/jobs/minibroker-integration-tests.tmpl
@@ -9,7 +9,7 @@
     params:
       include_source_tarball: true
   - get: {{ .backend }}-pool.kube-hosts
-    {{- if ne .position 0 }}
+    {{- if and (ne .position 0) (not .continue_on_failure) }}
     passed:
     - {{ index .jobs_enabled (sub .position 1) }}-{{ .scheduler }}-{{ .backend }}-{{ .avail }}
     {{- end }}

--- a/cap-ci/jobs/post-upgrade-smoke-tests.tmpl
+++ b/cap-ci/jobs/post-upgrade-smoke-tests.tmpl
@@ -5,7 +5,7 @@
   plan:
   - get: catapult
   - get: {{ .backend }}-pool.kube-hosts
-    {{- if ne .position 0 }}
+    {{- if and (ne .position 0) (not .continue_on_failure) }}
     passed:
     - {{ index .jobs_enabled (sub .position 1) }}-{{ .scheduler }}-{{ .backend }}-{{ .avail }}
     {{- end }}

--- a/cap-ci/jobs/sync-integration-tests.tmpl
+++ b/cap-ci/jobs/sync-integration-tests.tmpl
@@ -5,7 +5,7 @@
   plan:
   - get: catapult
   - get: {{ .backend }}-pool.kube-hosts
-    {{- if ne .position 0 }}
+    {{- if and (ne .position 0) (not .continue_on_failure) }}
     passed:
     - {{ index .jobs_enabled (sub .position 1) }}-{{ .scheduler }}-{{ .backend }}-{{ .avail }}
     {{- end }}

--- a/cap-ci/jobs/upgrade-kubecf.tmpl
+++ b/cap-ci/jobs/upgrade-kubecf.tmpl
@@ -7,7 +7,7 @@
     trigger: false
   - get: catapult
   - get: {{ .backend }}-pool.kube-hosts
-    {{- if ne .position 0 }}
+    {{- if and (ne .position 0) (not .continue_on_failure) }}
     passed:
     - {{ index .jobs_enabled (sub .position 1) }}-{{ .scheduler }}-{{ .backend }}-{{ .avail }}
     {{- end }}


### PR DESCRIPTION
Add new `continue_on_failure` option to all pipelines

- if false, no changes: failed jobs will not trigger the next.
- if true, failed jobs, besides deploy, destroy, smokes, upgrade,
pre-upgrade-smokes, will trigger the next job even if they fail.

Enabled in cap-pre-release-caasp.

Tested by enabling and disabling the option, seeing that there's either no changes when flying, or the specific changes.