### PR TITLE
update default ci configs to match what is actually deployed on concourse

### DIFF
--- a/cap-ci/cap-pre-release-caasp.yaml
+++ b/cap-ci/cap-pre-release-caasp.yaml
@@ -54,7 +54,7 @@ s3minibroker:
 s3:
   bucket: kubecf
   region: us-west-2
-  regexp: kubecf-bundle-v(.*).tgz
+  regexp: kubecf-bundle-v(2.5.*).tgz
 # Scheduling is required for nightly builds, enabling it removes regular trigger on kubecf bundle.
 schedule:
   enabled: false

--- a/cap-ci/cap-pre-release-caasp.yaml
+++ b/cap-ci/cap-pre-release-caasp.yaml
@@ -31,7 +31,7 @@ backends:
 availabilities:
   sa: true
   ha: true
-  all: true
+  all: false
 schedulers:
   diego: true
   eirini: true

--- a/cap-ci/cap-pre-release-upgrades-caasp.yaml
+++ b/cap-ci/cap-pre-release-upgrades-caasp.yaml
@@ -56,7 +56,7 @@ s3minibroker:
 s3:
   bucket: kubecf
   region: us-west-2
-  regexp: kubecf-bundle-v(.*).tgz
+  regexp: kubecf-bundle-v(2.5.*).tgz
 # Scheduling is required for nightly builds, enabling it removes regular trigger on kubecf bundle.
 schedule:
   enabled: false

--- a/cap-ci/cap-pre-release-upgrades-caasp.yaml
+++ b/cap-ci/cap-pre-release-upgrades-caasp.yaml
@@ -32,8 +32,8 @@ backends:
   eks: false
 availabilities:
   sa: false
-  ha: false
-  all: true
+  ha: true
+  all: false
 schedulers:
   diego: true
   eirini: true

--- a/cap-ci/cap-pre-release-upgrades.yaml
+++ b/cap-ci/cap-pre-release-upgrades.yaml
@@ -33,7 +33,7 @@ backends:
 availabilities:
   sa: false
   ha: true
-  all: true
+  all: false
 schedulers:
   diego: true
   eirini: true

--- a/cap-ci/cap-pre-release-upgrades.yaml
+++ b/cap-ci/cap-pre-release-upgrades.yaml
@@ -32,7 +32,7 @@ backends:
   eks: true
 availabilities:
   sa: false
-  ha: false
+  ha: true
   all: true
 schedulers:
   diego: true
@@ -56,10 +56,10 @@ s3minibroker:
 s3:
   bucket: kubecf
   region: us-west-2
-  regexp: kubecf-bundle-v(.*).tgz
+  regexp: kubecf-bundle-v(2.5.*).tgz
 # Scheduling is required for nightly builds, enabling it removes regular trigger on kubecf bundle.
 schedule:
-  enabled: true
+  enabled: false
   start: 12:00 AM
   stop: 12:10 AM
   location: America/Vancouver

--- a/cap-ci/cap-pre-release.yaml
+++ b/cap-ci/cap-pre-release.yaml
@@ -30,7 +30,7 @@ backends:
   eks: true
 availabilities:
   sa: false
-  ha: false
+  ha: true
   all: true
 schedulers:
   diego: true
@@ -54,10 +54,10 @@ s3minibroker:
 s3:
   bucket: kubecf
   region: us-west-2
-  regexp: kubecf-bundle-v(.*).tgz
+  regexp: kubecf-bundle-v(2.5.*).tgz
 # Scheduling is required for nightly builds, enabling it removes regular trigger on kubecf bundle.
 schedule:
-  enabled: true
+  enabled: false
   start: 12:00 AM
   stop: 12:10 AM
   location: America/Vancouver

--- a/cap-ci/cap-pre-release.yaml
+++ b/cap-ci/cap-pre-release.yaml
@@ -31,7 +31,7 @@ backends:
 availabilities:
   sa: false
   ha: true
-  all: true
+  all: false
 schedulers:
   diego: true
   eirini: true

--- a/cap-ci/cap-release-caasp.yaml
+++ b/cap-ci/cap-release-caasp.yaml
@@ -30,8 +30,8 @@ backends:
   eks: false
 availabilities:
   sa: false
-  ha: false
-  all: true
+  ha: true
+  all: false
 schedulers:
   diego: true
   eirini: true

--- a/cap-ci/cap-release-upgrades-caasp.yaml
+++ b/cap-ci/cap-release-upgrades-caasp.yaml
@@ -32,8 +32,8 @@ backends:
   eks: false
 availabilities:
   sa: false
-  ha: false
-  all: true
+  ha: true
+  all: false
 schedulers:
   diego: true
   eirini: true

--- a/cap-ci/cap-release-upgrades.yaml
+++ b/cap-ci/cap-release-upgrades.yaml
@@ -32,8 +32,8 @@ backends:
   eks: true
 availabilities:
   sa: false
-  ha: false
-  all: true
+  ha: true
+  all: false
 schedulers:
   diego: true
   eirini: true

--- a/cap-ci/cap-release.yaml
+++ b/cap-ci/cap-release.yaml
@@ -31,7 +31,7 @@ backends:
 availabilities:
   sa: false
   ha: true
-  all: true
+  all: false
 schedulers:
   diego: true
   eirini: true

--- a/cap-ci/cap-release.yaml
+++ b/cap-ci/cap-release.yaml
@@ -30,7 +30,7 @@ backends:
   eks: true
 availabilities:
   sa: false
-  ha: false
+  ha: true
   all: true
 schedulers:
   diego: true


### PR DESCRIPTION
This updates our default configs to reflect our current deployed pipelines' definition.

Deployed pipelines have the following changes:
-  regex used in pipelines is 2.5.X (until we can restart workers to clear the cache)
- had to disable nightly schedule on pre-release as kubecf bundles version are not correct. This lead to pipeline not picking master builds on nightly basis, instead it keeps testing last release RC on nightly basis. There is no point in keeping `schedule` enabled until we have some fix
- disable autoscaler, as kubecf runs into a race condition when enabled