### PR TITLE
Reflect current state of caasp pipelines

### DIFF
--- a/cap-ci/cap-pre-release-caasp.yaml
+++ b/cap-ci/cap-pre-release-caasp.yaml
@@ -44,7 +44,7 @@ brain:
   include: ""
   exclude: ""
 cats:
-  nodes: 3
+  nodes: 6
   flake-attempts: 5
   timeout-scale: "3.0"
 s3minibroker:

--- a/cap-ci/cap-pre-release-caasp.yaml
+++ b/cap-ci/cap-pre-release-caasp.yaml
@@ -11,7 +11,7 @@ jobs:
   cf-acceptance-tests: true
   upgrade-kubecf: true
   deploy-stratos: false
-  destroy-kubecf: true
+  destroy-kubecf: false
 jobs_ordered:
 - deploy-k8s
 - deploy-kubecf

--- a/cap-ci/cap-pre-release-upgrades-caasp.yaml
+++ b/cap-ci/cap-pre-release-upgrades-caasp.yaml
@@ -12,7 +12,7 @@ jobs:
   sync-integration-tests: true
   minibroker-integration-tests: true
   cf-acceptance-tests: true
-  destroy-kubecf: true
+  destroy-kubecf: false
 jobs_ordered:
 - deploy-k8s
 - pre-upgrade-deploy-kubecf

--- a/cap-ci/cap-pre-release-upgrades-caasp.yaml
+++ b/cap-ci/cap-pre-release-upgrades-caasp.yaml
@@ -31,8 +31,8 @@ backends:
   gke: false
   eks: false
 availabilities:
-  sa: false
-  ha: false
+  sa: true
+  ha: true
   all: true
 schedulers:
   diego: true

--- a/cap-ci/cap-pre-release-upgrades-caasp.yaml
+++ b/cap-ci/cap-pre-release-upgrades-caasp.yaml
@@ -46,7 +46,7 @@ brain:
   include: ""
   exclude: ""
 cats:
-  nodes: 3
+  nodes: 6
   flake-attempts: 5
   timeout-scale: "3.0"
 s3minibroker:

--- a/cap-ci/cap-release-caasp.yaml
+++ b/cap-ci/cap-release-caasp.yaml
@@ -29,8 +29,8 @@ backends:
   gke: false
   eks: false
 availabilities:
-  sa: false
-  ha: false
+  sa: true
+  ha: true
   all: true
 schedulers:
   diego: true

--- a/cap-ci/cap-release-caasp.yaml
+++ b/cap-ci/cap-release-caasp.yaml
@@ -44,7 +44,7 @@ brain:
   include: ""
   exclude: ""
 cats:
-  nodes: 3
+  nodes: 6
   flake-attempts: 5
   timeout-scale: "3.0"
 s3minibroker:

--- a/cap-ci/cap-release-caasp.yaml
+++ b/cap-ci/cap-release-caasp.yaml
@@ -11,7 +11,7 @@ jobs:
   cf-acceptance-tests: true
   upgrade-kubecf: true
   deploy-stratos: false
-  destroy-kubecf: true
+  destroy-kubecf: false
 jobs_ordered:
 - deploy-k8s
 - deploy-kubecf

--- a/cap-ci/cap-release-upgrades-caasp.yaml
+++ b/cap-ci/cap-release-upgrades-caasp.yaml
@@ -12,7 +12,7 @@ jobs:
   sync-integration-tests: true
   minibroker-integration-tests: true
   cf-acceptance-tests: true
-  destroy-kubecf: true
+  destroy-kubecf: false
 jobs_ordered:
 - deploy-k8s
 - pre-upgrade-deploy-kubecf

--- a/cap-ci/cap-release-upgrades-caasp.yaml
+++ b/cap-ci/cap-release-upgrades-caasp.yaml
@@ -31,8 +31,8 @@ backends:
   gke: false
   eks: false
 availabilities:
-  sa: false
-  ha: false
+  sa: true
+  ha: true
   all: true
 schedulers:
   diego: true

--- a/cap-ci/cap-release-upgrades-caasp.yaml
+++ b/cap-ci/cap-release-upgrades-caasp.yaml
@@ -46,7 +46,7 @@ brain:
   include: ""
   exclude: ""
 cats:
-  nodes: 3
+  nodes: 6
   flake-attempts: 5
   timeout-scale: "3.0"
 s3minibroker:


### PR DESCRIPTION
Increase cats ginkgo nodes to 6 in caasp pipelines.

Disable destroy-kubecf in caasp pipelines:
KubeCF gets cleaned on installation anyways, and its nice to have the cluster
set up at the end for debugging or reusing, since they are pets.

Enable all availabilities in caasp pipelines, We will just pause those that we aren't testing.

