### PR TITLE
Update s3.kubecf regexp to new artifact format

### DIFF
--- a/cap-ci/cap-pre-release-caasp.yaml
+++ b/cap-ci/cap-pre-release-caasp.yaml
@@ -54,7 +54,7 @@ s3minibroker:
 s3:
   bucket: kubecf
   region: us-west-2
-  regexp: kubecf-bundle-v(.*).tgz
+  regexp: kubecf-bundle-v(.*)-(.*\..*).tgz
 # Scheduling is required for nightly builds, enabling it removes regular trigger on kubecf bundle.
 schedule:
   enabled: false

--- a/cap-ci/cap-pre-release-upgrades-caasp.yaml
+++ b/cap-ci/cap-pre-release-upgrades-caasp.yaml
@@ -56,7 +56,7 @@ s3minibroker:
 s3:
   bucket: kubecf
   region: us-west-2
-  regexp: kubecf-bundle-v(.*).tgz
+  regexp: kubecf-bundle-v(.*)-(.*\..*).tgz
 # Scheduling is required for nightly builds, enabling it removes regular trigger on kubecf bundle.
 schedule:
   enabled: false

--- a/cap-ci/cap-pre-release-upgrades.yaml
+++ b/cap-ci/cap-pre-release-upgrades.yaml
@@ -56,7 +56,7 @@ s3minibroker:
 s3:
   bucket: kubecf
   region: us-west-2
-  regexp: kubecf-bundle-v(.*).tgz
+  regexp: kubecf-bundle-v(.*)-(.*\..*).tgz
 # Scheduling is required for nightly builds, enabling it removes regular trigger on kubecf bundle.
 schedule:
   enabled: true

--- a/cap-ci/cap-pre-release.yaml
+++ b/cap-ci/cap-pre-release.yaml
@@ -54,7 +54,7 @@ s3minibroker:
 s3:
   bucket: kubecf
   region: us-west-2
-  regexp: kubecf-bundle-v(.*).tgz
+  regexp: kubecf-bundle-v(.*)-(.*\..*).tgz
 # Scheduling is required for nightly builds, enabling it removes regular trigger on kubecf bundle.
 schedule:
   enabled: true


### PR DESCRIPTION
`kubecf-bundle-v(.*)-(.*\..*).tgz`:
- 1st capturing group is the semver, as expected in
  https://github.com/concourse/s3-resource#file-names
  "The first grouped match is used to extract the version".
- 2nd capturing group is our artifact information: expect anything, but at least
  1 dot in the middle of the group. The idea here is a bit of future-proofing
  if we drop the number of commits in the middle.

This regexp doesn't match the old artifact formats, `kubecf-bundle-v0.0.0-fef5111.tgz`, which is what we want.