### PR TITLE
add a job to clean and release pet clusters

### DIFF
--- a/cap-ci/cap-pre-release-caasp.yaml
+++ b/cap-ci/cap-pre-release-caasp.yaml
@@ -11,6 +11,7 @@ jobs:
   cf-acceptance-tests: true
   upgrade-kubecf: true
   deploy-stratos: false
+  clean-cap: true
   destroy-kubecf: false
 jobs_ordered:
 - deploy-k8s
@@ -22,6 +23,7 @@ jobs_ordered:
 - minibroker-integration-tests
 - cf-acceptance-tests-brain
 - deploy-stratos
+- clean-cap
 - destroy-kubecf
 backends:
   caasp4: true

--- a/cap-ci/cap-pre-release-upgrades-caasp.yaml
+++ b/cap-ci/cap-pre-release-upgrades-caasp.yaml
@@ -12,6 +12,7 @@ jobs:
   sync-integration-tests: true
   minibroker-integration-tests: true
   cf-acceptance-tests: true
+  clean-cap: true
   destroy-kubecf: false
 jobs_ordered:
 - deploy-k8s
@@ -24,6 +25,7 @@ jobs_ordered:
 - cf-acceptance-tests
 - minibroker-integration-tests
 - cf-acceptance-tests-brain
+- clean-cap
 - destroy-kubecf
 backends:
   caasp4: true

--- a/cap-ci/cap-release-caasp.yaml
+++ b/cap-ci/cap-release-caasp.yaml
@@ -11,6 +11,7 @@ jobs:
   cf-acceptance-tests: true
   upgrade-kubecf: true
   deploy-stratos: false
+  clean-cap: true
   destroy-kubecf: false
 jobs_ordered:
 - deploy-k8s
@@ -22,6 +23,7 @@ jobs_ordered:
 - minibroker-integration-tests
 - cf-acceptance-tests-brain
 - deploy-stratos
+- clean-cap
 - destroy-kubecf
 backends:
   caasp4: true

--- a/cap-ci/cap-release-upgrades-caasp.yaml
+++ b/cap-ci/cap-release-upgrades-caasp.yaml
@@ -12,6 +12,7 @@ jobs:
   sync-integration-tests: true
   minibroker-integration-tests: true
   cf-acceptance-tests: true
+  clean-cap: true
   destroy-kubecf: false
 jobs_ordered:
 - deploy-k8s
@@ -24,6 +25,7 @@ jobs_ordered:
 - cf-acceptance-tests
 - minibroker-integration-tests
 - cf-acceptance-tests-brain
+- clean-cap
 - destroy-kubecf
 backends:
   caasp4: true

--- a/cap-ci/jobs/clean-cap.tmpl
+++ b/cap-ci/jobs/clean-cap.tmpl
@@ -1,0 +1,41 @@
+{{ define "jobs_clean-cap" }}
+- name: clean-cap-{{ .scheduler }}-{{ .backend }}-{{ .avail }}
+  serial_groups: [{{ .scheduler }}-{{ .backend }}-{{ .avail }}]
+  public: false
+  plan:
+  - get: catapult
+  - get: {{ .backend }}-pool.kube-hosts
+    passed:
+    - {{ index .jobs_enabled (sub .position 1) }}-{{ .scheduler }}-{{ .backend }}-{{ .avail }}
+    trigger: true
+  - task: clean-cap-{{ .scheduler }}
+    timeout: 5h30m
+    input_mapping:
+      pool.kube-hosts: {{ .backend }}-pool.kube-hosts
+    config:
+      platform: linux
+      image_resource:
+        type: registry-image
+        source:
+          repository: splatform/catapult
+      inputs:
+      - name: catapult
+      - name: pool.kube-hosts
+      params:
+        QUIET_OUTPUT: true
+        DOWNLOAD_CATAPULT_DEPS: false
+      run:
+        path: "/bin/bash"
+        args:
+          - -c
+          - |
+            {{ tmpl.Exec "scripts_obtain_kubeconfig" | indent 12 | trimSpace }}
+            {{ tmpl.Exec ( print "scripts_import_" .backend ) | indent 12 | trimSpace }}
+            {{- if index .jobs "stratos" }}
+            {{ tmpl.Exec "scripts_destroy_stratos" | indent 12 | trimSpace }}
+            {{- end}}
+            {{ tmpl.Exec "scripts_clean_cap" | indent 12 | trimSpace }}
+  - put: {{ .backend }}-pool.kube-hosts
+    params:
+      release: {{ .backend }}-pool.kube-hosts
+{{ end }}

--- a/cap-ci/jobs/clean-cap.tmpl
+++ b/cap-ci/jobs/clean-cap.tmpl
@@ -25,16 +25,16 @@
         QUIET_OUTPUT: true
         DOWNLOAD_CATAPULT_DEPS: false
       run:
-        path: "/bin/bash"
+        path: /bin/bash
         args:
-          - -c
-          - |
-            {{ tmpl.Exec "scripts_obtain_kubeconfig" | indent 12 | trimSpace }}
-            {{ tmpl.Exec ( print "scripts_import_" .backend ) | indent 12 | trimSpace }}
-            {{- if index .jobs "stratos" }}
-            {{ tmpl.Exec "scripts_destroy_stratos" | indent 12 | trimSpace }}
-            {{- end}}
-            {{ tmpl.Exec "scripts_clean_cap" | indent 12 | trimSpace }}
+        - -c
+        - |
+          {{ tmpl.Exec "scripts_obtain_kubeconfig" | indent 12 | trimSpace }}
+          {{ tmpl.Exec ( print "scripts_import_" .backend ) | indent 12 | trimSpace }}
+          {{- if index .jobs "stratos" }}
+          {{ tmpl.Exec "scripts_destroy_stratos" | indent 12 | trimSpace }}
+          {{- end}}
+          {{ tmpl.Exec "scripts_clean_cap" | indent 12 | trimSpace }}
   - put: {{ .backend }}-pool.kube-hosts
     params:
       release: {{ .backend }}-pool.kube-hosts

--- a/cap-ci/scripts/clean_cap.tmpl
+++ b/cap-ci/scripts/clean_cap.tmpl
@@ -1,0 +1,4 @@
+{{ define "scripts_clean_cap" }}
+{{- /* deletes CAP installation */}}
+make kubecf-clean
+{{ end }}


### PR DESCRIPTION
added a job `clean-cap`; to clean deployed CAP and release the lock from the pool.

Tested: https://concourse.suse.dev/teams/main/pipelines/prabal-pet-cluster-cleanup
