### PR TITLE
add nightly CI yamls

### DIFF
--- a/cap-ci/cap-nightly-caasp.yaml
+++ b/cap-ci/cap-nightly-caasp.yaml
@@ -1,38 +1,38 @@
 workertags:
-  # caasp4: suse-internal
+  caasp4: suse-internal
 
 jobs:
-  deploy-k8s: true
-  pre-upgrade-deploy-kubecf: true
-  pre-upgrade-smoke-tests: true
-  deploy-stratos: false
-  upgrade-kubecf: true
-  post-upgrade-smoke-tests: true
+  deploy-k8s: false
+  deploy-kubecf: true
+  smoke-tests: true
   cf-acceptance-tests-brain: true
   sync-integration-tests: true
   minibroker-integration-tests: true
   cf-acceptance-tests: true
-  destroy-kubecf: true
+  upgrade-kubecf: true
+  deploy-stratos: false
+  clean-cap: true
+  destroy-kubecf: false
 jobs_ordered:
 - deploy-k8s
-- pre-upgrade-deploy-kubecf
-- pre-upgrade-smoke-tests
-- deploy-stratos
-- upgrade-kubecf
-- post-upgrade-smoke-tests
-- cf-acceptance-tests-brain
+- deploy-kubecf
+- smoke-tests
 - sync-integration-tests
-- minibroker-integration-tests
 - cf-acceptance-tests
+- upgrade-kubecf
+- minibroker-integration-tests
+- cf-acceptance-tests-brain
+- deploy-stratos
+- clean-cap
 - destroy-kubecf
 backends:
-  caasp4: false
-  aks: true
-  gke: true
-  eks: true
+  caasp4: true
+  aks: false
+  gke: false
+  eks: false
 availabilities:
-  sa: false
-  ha: false
+  sa: true
+  ha: true
   all: true
 schedulers:
   diego: true
@@ -56,12 +56,12 @@ s3minibroker:
 s3:
   bucket: kubecf
   region: us-west-2
-  regexp: kubecf-bundle-v(.*).tgz
+  regexp: kubecf-bundle-v0.0.0-(.*\..*).tgz
 # Scheduling is required for nightly builds, enabling it removes regular trigger on kubecf bundle.
 schedule:
-  enabled: false
+  enabled: true
   start: 12:00 AM
   stop: 12:10 AM
   location: America/Vancouver
 logs:
-  enabled: true
+  enabled: false

--- a/cap-ci/cap-nightly-upgrades-caasp.yaml
+++ b/cap-ci/cap-nightly-upgrades-caasp.yaml
@@ -1,8 +1,8 @@
 workertags:
-  # caasp4: suse-internal
+  caasp4: suse-internal
 
 jobs:
-  deploy-k8s: true
+  deploy-k8s: false
   pre-upgrade-deploy-kubecf: true
   pre-upgrade-smoke-tests: true
   deploy-stratos: false
@@ -12,7 +12,8 @@ jobs:
   sync-integration-tests: true
   minibroker-integration-tests: true
   cf-acceptance-tests: true
-  destroy-kubecf: true
+  clean-cap: true
+  destroy-kubecf: false
 jobs_ordered:
 - deploy-k8s
 - pre-upgrade-deploy-kubecf
@@ -20,19 +21,20 @@ jobs_ordered:
 - deploy-stratos
 - upgrade-kubecf
 - post-upgrade-smoke-tests
-- cf-acceptance-tests-brain
 - sync-integration-tests
-- minibroker-integration-tests
 - cf-acceptance-tests
+- minibroker-integration-tests
+- cf-acceptance-tests-brain
+- clean-cap
 - destroy-kubecf
 backends:
-  caasp4: false
-  aks: true
-  gke: true
-  eks: true
+  caasp4: true
+  aks: false
+  gke: false
+  eks: false
 availabilities:
-  sa: false
-  ha: false
+  sa: true
+  ha: true
   all: true
 schedulers:
   diego: true
@@ -46,7 +48,7 @@ brain:
   include: ""
   exclude: ""
 cats:
-  nodes: 3
+  nodes: 6
   flake-attempts: 5
   timeout-scale: "3.0"
 s3minibroker:
@@ -56,12 +58,12 @@ s3minibroker:
 s3:
   bucket: kubecf
   region: us-west-2
-  regexp: kubecf-bundle-v(.*).tgz
+  regexp: kubecf-bundle-v0.0.0-(.*\..*).tgz
 # Scheduling is required for nightly builds, enabling it removes regular trigger on kubecf bundle.
 schedule:
-  enabled: false
+  enabled: true
   start: 12:00 AM
   stop: 12:10 AM
   location: America/Vancouver
 logs:
-  enabled: true
+  enabled: false

--- a/cap-ci/cap-nightly-upgrades.yaml
+++ b/cap-ci/cap-nightly-upgrades.yaml
@@ -56,10 +56,10 @@ s3minibroker:
 s3:
   bucket: kubecf
   region: us-west-2
-  regexp: kubecf-bundle-v(.*).tgz
+  regexp: kubecf-bundle-v0.0.0-(.*\..*).tgz
 # Scheduling is required for nightly builds, enabling it removes regular trigger on kubecf bundle.
 schedule:
-  enabled: false
+  enabled: true
   start: 12:00 AM
   stop: 12:10 AM
   location: America/Vancouver

--- a/cap-ci/cap-nightly.yaml
+++ b/cap-ci/cap-nightly.yaml
@@ -3,27 +3,25 @@ workertags:
 
 jobs:
   deploy-k8s: true
-  pre-upgrade-deploy-kubecf: true
-  pre-upgrade-smoke-tests: true
-  deploy-stratos: false
-  upgrade-kubecf: true
-  post-upgrade-smoke-tests: true
+  deploy-kubecf: true
+  smoke-tests: true
   cf-acceptance-tests-brain: true
   sync-integration-tests: true
   minibroker-integration-tests: true
   cf-acceptance-tests: true
+  upgrade-kubecf: true
+  deploy-stratos: false
   destroy-kubecf: true
 jobs_ordered:
 - deploy-k8s
-- pre-upgrade-deploy-kubecf
-- pre-upgrade-smoke-tests
-- deploy-stratos
-- upgrade-kubecf
-- post-upgrade-smoke-tests
+- deploy-kubecf
+- smoke-tests
 - cf-acceptance-tests-brain
 - sync-integration-tests
 - minibroker-integration-tests
 - cf-acceptance-tests
+- upgrade-kubecf
+- deploy-stratos
 - destroy-kubecf
 backends:
   caasp4: false
@@ -56,10 +54,10 @@ s3minibroker:
 s3:
   bucket: kubecf
   region: us-west-2
-  regexp: kubecf-bundle-v(.*).tgz
+  regexp: kubecf-bundle-v0.0.0-(.*\..*).tgz
 # Scheduling is required for nightly builds, enabling it removes regular trigger on kubecf bundle.
 schedule:
-  enabled: false
+  enabled: true
   start: 12:00 AM
   stop: 12:10 AM
   location: America/Vancouver

--- a/cap-ci/cap-pre-release.yaml
+++ b/cap-ci/cap-pre-release.yaml
@@ -57,7 +57,7 @@ s3:
   regexp: kubecf-bundle-v(.*).tgz
 # Scheduling is required for nightly builds, enabling it removes regular trigger on kubecf bundle.
 schedule:
-  enabled: true
+  enabled: false
   start: 12:00 AM
   stop: 12:10 AM
   location: America/Vancouver


### PR DESCRIPTION
**Needs** https://github.com/SUSE/cap/pull/73

- This PR adds default yamls for nightly CIs. 

- Turns off nightly run flag for pre-release CIs as they are suppose to kubecf releases not master.

PS: These yamls replicates the flags enablement of corresponding pre-release yamls, so if there seems to be a need to set some CAP installation flags to false or true (eg. SA, HA), it should be part of a separate PR. This PR focusses on nightly regex and enablement of nightly run flag.