### PR TITLE
fix schedule condition for pet clusters in deploy-kubecf job

### DIFF
--- a/cap-ci/jobs/deploy-kubecf.tmpl
+++ b/cap-ci/jobs/deploy-kubecf.tmpl
@@ -6,8 +6,8 @@
   {{- if not (index .jobs "deploy-k8s") }}
   - get: schedule-interval
     trigger: true
-  {{ end }}
-  {{ end }}
+  {{- end }}
+  {{- end }}
   - get: s3.kubecf-bundle
     {{- if not (index .jobs "deploy-k8s") }}
     {{- if not .schedule.enabled }}

--- a/cap-ci/jobs/deploy-kubecf.tmpl
+++ b/cap-ci/jobs/deploy-kubecf.tmpl
@@ -2,9 +2,17 @@
 - name: deploy-kubecf-{{ .scheduler }}-{{ .backend }}-{{ .avail }}
   public: false
   plan:
+  {{- if eq .schedule.enabled true }}
+  {{- if not (index .jobs "deploy-k8s") }}
+  - get: schedule-interval
+    trigger: true
+  {{ end }}
+  {{ end }}
   - get: s3.kubecf-bundle
     {{- if not (index .jobs "deploy-k8s") }}
+    {{- if not .schedule.enabled }}
     trigger: true
+    {{- end }}
     {{- end }}
   {{- if index .jobs "deploy-stratos" }}
   - get: helm-chart.stratos-chart

--- a/cap-ci/jobs/deploy-kubecf.tmpl
+++ b/cap-ci/jobs/deploy-kubecf.tmpl
@@ -2,7 +2,7 @@
 - name: deploy-kubecf-{{ .scheduler }}-{{ .backend }}-{{ .avail }}
   public: false
   plan:
-  {{- if eq .schedule.enabled true }}
+  {{- if .schedule.enabled }}
   {{- if not (index .jobs "deploy-k8s") }}
   - get: schedule-interval
     trigger: true


### PR DESCRIPTION
fixes:
./create_pipeline.sh concourse.suse.dev cap-nightly-caasp
```
apply configuration? [yN]: y
error: invalid pipeline config:
invalid resources:
	resource 'schedule-interval' is not used

```