### PR TITLE
fix schedule condition for pet clusters in pre-upgrade-deploy-kubecf job

### DIFF
--- a/cap-ci/jobs/pre-upgrade-deploy-kubecf.tmpl
+++ b/cap-ci/jobs/pre-upgrade-deploy-kubecf.tmpl
@@ -2,9 +2,15 @@
 - name: pre-upgrade-deploy-kubecf-{{ .scheduler }}-{{ .backend }}-{{ .avail }}
   public: false
   plan:
+  {{- if .schedule.enabled }}
+  - get: schedule-interval
+    trigger: true
+  {{- end }}
   {{- if not (index .jobs "deploy-k8s") }}
+  {{- if not .schedule.enabled }}
   - get: s3.kubecf-bundle
     trigger: true
+  {{- end }}
   {{- end }}
   - get: helm-chart.kubecf-chart
   - get: helm-chart.cfo-chart


### PR DESCRIPTION
fixes: 
./create_pipeline.sh concourse.suse.dev cap-nightly-upgrades-caasp

```
apply configuration? [yN]: y
error: invalid pipeline config:
invalid resources:
	resource 'schedule-interval' is not used
```
similar to https://github.com/SUSE/cap/pull/77